### PR TITLE
Support for glob-ish path in files config

### DIFF
--- a/src/File/Glob.php
+++ b/src/File/Glob.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mark Story (http://mark-story.com)
+ * @since         0.0.5
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\File;
+
+/**
+ * Wrapper for glob patterns that are used in asset targets.
+ */
+class Glob
+{
+    protected $basePath;
+    protected $pattern;
+
+    public function __construct($basePath, $pattern)
+    {
+        if (!is_dir($basePath)) {
+            throw new \RuntimeException("$basePath does not exist.");
+        }
+
+        $this->basePath = $basePath;
+        $this->pattern = $pattern;
+    }
+
+    public function files()
+    {
+        $files = [];
+        foreach (glob($this->basePath . $this->pattern) as $file) {
+            if (is_file($file)) {
+                $files[] = new Local($file);
+            }
+        }
+
+        return $files;
+    }
+}

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -29,6 +29,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->themedFile = APP . 'config' . DS . 'themed.ini';
         $this->pluginFile = APP . 'config' . DS . 'plugins.ini';
         $this->overrideFile = APP . 'config' . DS . 'overridable.local.ini';
+        $this->globFile = APP . 'config' . DS . 'glob.ini';
     }
 
     public function testFilterRegistry()
@@ -103,6 +104,45 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             APP . 'js/classes/base_class.js',
             $files[2]->path()
+        );
+    }
+
+    public function testAssetCollectionGlob()
+    {
+        $config = AssetConfig::buildFromIniFile($this->globFile);
+        $factory = new Factory($config);
+        $collection = $factory->assetCollection();
+
+        $this->assertCount(1, $collection);
+        $this->assertTrue($collection->contains('all_classes.js'));
+
+        $asset = $collection->get('all_classes.js');
+        $files = $asset->files();
+
+        $this->assertCount(6, $files, 'Not enough files');
+        $this->assertEquals(
+            APP . 'js/classes/base_class.js',
+            $files[0]->path()
+        );
+        $this->assertEquals(
+            APP . 'js/classes/base_class_two.js',
+            $files[1]->path()
+        );
+        $this->assertEquals(
+            APP . 'js/classes/double_inclusion.js',
+            $files[2]->path()
+        );
+        $this->assertEquals(
+            APP . 'js/classes/nested_class.js',
+            $files[3]->path()
+        );
+        $this->assertEquals(
+            APP . 'js/classes/slideshow.js',
+            $files[4]->path()
+        );
+        $this->assertEquals(
+            APP . 'js/classes/template.js',
+            $files[5]->path()
         );
     }
 

--- a/tests/TestCase/File/GlobTest.php
+++ b/tests/TestCase/File/GlobTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mark Story (http://mark-story.com)
+ * @since         0.0.5
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\Test\TestCase\File;
+
+use MiniAsset\File\Glob;
+
+class GlobTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testErrorOnInvalidBasePath()
+    {
+        $file = new Glob('/invalid/', '*');
+    }
+
+    public function testFiles()
+    {
+        $glob = new Glob(dirname(__FILE__) . DS, '*');
+        $files = $glob->files();
+        $this->assertCount(3, $files);
+        $this->assertEquals('GlobTest.php', $files[0]->name());
+        $this->assertEquals('LocalTest.php', $files[1]->name());
+        $this->assertEquals('RemoteTest.php', $files[2]->name());
+    }
+}

--- a/tests/test_files/config/glob.ini
+++ b/tests/test_files/config/glob.ini
@@ -1,0 +1,7 @@
+[General]
+
+[js]
+paths[] = WEBROOT/js/*
+
+[all_classes.js]
+files[] = classes/*


### PR DESCRIPTION
Adds support for glob-ish paths in asset files config. I don't know if this is a feature you will accept, but it's  very useful for me when I have many files under a certain directory and I want to include all of them at once instead of having to write down one by one manually.
Otherwise, if you think there are any improvements to make before merging let me know.
