### PR TITLE
Extend config

### DIFF
--- a/config/assets.sample.ini
+++ b/config/assets.sample.ini
@@ -55,6 +55,16 @@ files[] = mootools.js
 files[] = class.js
 filters[] = UglifyJs
 
+; Build targets can 'extend' other targets.
+; When a target extends another target, all the `files`
+; `filters` and `paths` are inherited from the 'parent' target.
+; The extending targets components are appended to the parents.
+; You can have assets extend to any depth that is necessary.
+[extended.js]
+extend = libs.js
+files[] = extended.js
+
+
 ; Create the CSS extension
 ; See the `[js]` section above for valid options.
 [css]

--- a/tests/test_files/config/extended.ini
+++ b/tests/test_files/config/extended.ini
@@ -1,0 +1,33 @@
+[General]
+
+[js]
+cachePath = WEBROOT/cache_js
+paths[] = APP/js
+
+[libs.js]
+files[] = classes/base_class.js
+files[] = classes/template.js
+filters[] = Sprockets
+
+[second.js]
+extend = extended.js
+files[] = lots_of_comments.js
+
+[theme_base.js]
+extend = libs.js
+theme = true
+
+[theme.js]
+extend = theme_base.js
+files[] = lots_of_comments.js
+
+[more.js]
+extend = extended.js
+files[] = local_script.js
+filters[] = JsMinFilter
+
+[extended.js]
+extend = libs.js
+files[] = library_file.js
+filters[] = JsMinFilter
+


### PR DESCRIPTION
Allow targets to recursively extend other targets. Extending a target will inherit the files, theme and filters settings.

Fixes markstory/asset_compress#263
