### PR TITLE
Added LessDotPHP filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,6 @@
     "tedivm/jshrink": "For using the JShrink filter.",
     "linkorb/jsmin-php": "For using the JSMin filter.",
     "leafo/scssphp": "For using the ScssPHP filter.",
-    "leafo/lessphp": "For using the LessPHP filter."
+    "oyejorge/less.php": "For using the LessDotPHP filter, see https://github.com/oyejorge/less.php"
   }
 }

--- a/src/Filter/LessDotPHP.php
+++ b/src/Filter/LessDotPHP.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mark Story (http://mark-story.com)
+ * @since         0.0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\Filter;
+
+/**
+ * Pre-processing filter that adds support for LESS.css files.
+ *
+ * Requires oyejorge/less.php to be installed via composer.
+ *
+ * @see https://github.com/oyejorge/less.php
+ */
+class LessDotPHP extends AssetFilter
+{
+    use CssDependencyTrait;
+
+    protected $_settings = array(
+        'ext' => '.less',
+        'paths' => [],
+    );
+
+    /**
+     * Runs `lessc` against any files that match the configured extension.
+     *
+     * @param string $filename The name of the input file.
+     * @param string $input The content of the file.
+     * @return string
+     * @throws \Exception
+     */
+    public function input($filename, $input)
+    {
+        if (substr($filename,
+                strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']
+        ) {
+            return $input;
+        }
+        if (!class_exists('\Less_Parser')) {
+            throw new \Exception('Cannot not load "\Less_Parser" class. Make sure https://github.com/oyejorge/less.php is installed.');
+        }
+
+        $parser = new \Less_Parser();
+
+        return $parser->parseFile($filename)->getCss();
+    }
+}
+

--- a/src/Filter/LessDotPHP.php
+++ b/src/Filter/LessDotPHP.php
@@ -39,9 +39,7 @@ class LessDotPHP extends AssetFilter
      */
     public function input($filename, $input)
     {
-        if (substr($filename,
-                strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']
-        ) {
+        if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $input;
         }
         if (!class_exists('\Less_Parser')) {
@@ -53,4 +51,3 @@ class LessDotPHP extends AssetFilter
         return $parser->parseFile($filename)->getCss();
     }
 }
-


### PR DESCRIPTION
Leafo's LessPHP is dead, and cannot parse newer syntax (e.g. it'll break on `&.extends`).

https://github.com/oyejorge/less.php is meant to replace it, and it's pretty much a drop-in replacement, minor alterations only. This is a filter wrapper for it. Additionally, might be useful to remove the old filter and to no longer recommend its installation, because the classes of these two filters will clash anyway if both are installed.
