### PR TITLE
Fix paths not being expanded in filters.

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -141,6 +141,8 @@ class Factory
 
         $files = [];
         $scanner = $this->scanner($paths);
+        $paths = $scanner->paths();
+
         foreach ($this->config->files($name) as $file) {
             if (preg_match('#^https?://#', $file)) {
                 $files[] = new Remote($file);

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -136,8 +136,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $asset = $collection->get('libs.js');
         $this->assertCount(2, $asset->files(), 'Not enough files');
         $paths = [
-            APP . 'js',
-            APP . 'js/other_path',
+            APP . 'js/',
+            APP . 'js/other_path/',
         ];
         $this->assertEquals($paths, $asset->paths(), 'Paths are incorrect');
         $this->assertEquals(['Sprockets'], $asset->filterNames(), 'Filters are incorrect');
@@ -181,33 +181,26 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($collection->contains('all_classes.js'));
 
         $asset = $collection->get('all_classes.js');
-        $files = $asset->files();
 
+        $this->assertEquals(
+            [APP . 'js/', APP . 'js/classes/', APP . 'js/secondary/'],
+            $asset->paths(),
+            'Should have expanded paths'
+        );
+
+        $files = $asset->files();
         $this->assertCount(6, $files, 'Not enough files');
-        $this->assertEquals(
+        $expectedPaths = [
             APP . 'js/classes/base_class.js',
-            $files[0]->path()
-        );
-        $this->assertEquals(
             APP . 'js/classes/base_class_two.js',
-            $files[1]->path()
-        );
-        $this->assertEquals(
             APP . 'js/classes/double_inclusion.js',
-            $files[2]->path()
-        );
-        $this->assertEquals(
             APP . 'js/classes/nested_class.js',
-            $files[3]->path()
-        );
-        $this->assertEquals(
             APP . 'js/classes/slideshow.js',
-            $files[4]->path()
-        );
-        $this->assertEquals(
             APP . 'js/classes/template.js',
-            $files[5]->path()
-        );
+        ];
+        foreach ($expectedPaths as $i => $expected) {
+            $this->assertEquals($expected, $files[$i]->path());
+        }
     }
 
     public function testWriter()


### PR DESCRIPTION
Expand paths before creating asset targets. This ensures that paths have been expanded when filters get configured from the asset target.

Refs #21
