### PR TITLE
Add support for `require` and intermediary builds

### DIFF
--- a/config/assets.sample.ini
+++ b/config/assets.sample.ini
@@ -64,6 +64,13 @@ filters[] = UglifyJs
 extend = libs.js
 files[] = extended.js
 
+; Build targets can 'require' another target.
+; When a target requires another target, the required target is
+; compiled including filter application, and used as a source
+; file for the new build.
+[dependent.js]
+require = extended.js
+files[] = drop/lib.js
 
 ; Create the CSS extension
 ; See the `[js]` section above for valid options.

--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -441,7 +441,7 @@ class AssetConfig
     }
 
     /**
-     * Get/set the list of files that match the given build file.
+     * Get the list of files that match the given build file.
      *
      * @param string $target The build file with extension.
      * @return array An array of files for the chosen build.
@@ -450,6 +450,24 @@ class AssetConfig
     {
         if (isset($this->_targets[$target]['files'])) {
             return (array)$this->_targets[$target]['files'];
+        }
+        return [];
+    }
+
+    /**
+     * Get the required build targets for this target.
+     *
+     * Required builds differ from extends in that the compiled
+     * asset is merged into the named target. In extends, the
+     * source files & filter for an asset are merged into a target.
+     *
+     * @param string $target The target to get requirements for.
+     * @return array A list of required builds.
+     */
+    public function requires($target)
+    {
+        if (isset($this->_targets[$target]['require'])) {
+            return (array)$this->_targets[$target]['require'];
         }
         return [];
     }
@@ -560,6 +578,7 @@ class AssetConfig
             'filters' => [],
             'theme' => false,
             'extend' => false,
+            'require' => [],
         ];
         if (!empty($config['paths'])) {
             $config['paths'] = array_map(array($this, '_replacePathConstants'), (array)$config['paths']);

--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -565,6 +565,17 @@ class AssetConfig
     }
 
     /**
+     * Check if the named target exists.
+     *
+     * @param string $name The name of the target to check.
+     * @return bool
+     */
+    public function hasTarget($name)
+    {
+        return isset($this->_targets[$name]);
+    }
+
+    /**
      * Create a new build target.
      *
      * @param string $target Name of the target file. The extension will be inferred based on the last extension.

--- a/src/Cli/BuildTask.php
+++ b/src/Cli/BuildTask.php
@@ -15,6 +15,7 @@ namespace MiniAsset\Cli;
 
 use MiniAsset\Cli\BaseTask;
 use MiniAsset\Factory;
+use \Exception;
 
 /**
  * Provides the `mini_asset build` command.
@@ -104,11 +105,11 @@ class BuildTask extends BaseTask
         $writer->invalidate($build);
         $name = $writer->buildFileName($build);
         try {
-            $this->verbose('<green>Saving file</green> for ' . $name, '.');
             $contents = $compiler->generate($build);
             $writer->write($build, $contents);
+            $this->verbose('<green>Saved file</green> for ' . $name, '.');
         } catch (Exception $e) {
-            $this->cli->err('Error: ' . $e->getMessage());
+            $this->cli->err('<red>Error:</red> ' . $e->getMessage());
         }
     }
 }

--- a/src/Cli/BuildTask.php
+++ b/src/Cli/BuildTask.php
@@ -93,7 +93,7 @@ class BuildTask extends BaseTask
     protected function _buildTarget($factory, $build)
     {
         $writer = $factory->writer();
-        $compiler = $factory->compiler();
+        $compiler = $factory->cachedCompiler();
 
         $name = $writer->buildFileName($build);
         if ($writer->isFresh($build) && !$this->cli->arguments->defined('force')) {

--- a/src/Cli/MiniAsset.php
+++ b/src/Cli/MiniAsset.php
@@ -44,6 +44,9 @@ class MiniAsset
                 return $this->build->main($argv);
             case 'clear':
                 return $this->clear->main($argv);
+            default:
+                $this->help();
+                return 1;
         }
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -20,6 +20,7 @@ use MiniAsset\File\Callback;
 use MiniAsset\File\Local;
 use MiniAsset\File\Remote;
 use MiniAsset\File\Glob;
+use MiniAsset\File\Target;
 use MiniAsset\Filter\FilterRegistry;
 use MiniAsset\Output\AssetCacher;
 use MiniAsset\Output\AssetWriter;
@@ -181,7 +182,13 @@ class Factory
                 }
             }
         }
-
+        $required = $this->config->requires($name);
+        if ($required) {
+            $compiler = $this->compiler();
+            foreach ($required as $dependency) {
+                $files[] = new Target($this->target($dependency), $compiler);
+            }
+        }
         return new AssetTarget($target, $files, $filters, $paths, $themed);
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -164,7 +164,7 @@ class Factory
 
         $required = $this->config->requires($name);
         if ($required) {
-            $compiler = $this->compiler();
+            $compiler = $this->cachedCompiler();
             foreach ($required as $dependency) {
                 $files[] = new Target($this->target($dependency), $compiler);
             }

--- a/src/File/Target.php
+++ b/src/File/Target.php
@@ -43,7 +43,7 @@ class Target implements FileInterface
 
     public function contents()
     {
-        return $this->compiler->build($this->target);
+        return $this->compiler->generate($this->target);
     }
 
     public function modifiedTime()

--- a/src/File/Target.php
+++ b/src/File/Target.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mark Story (http://mark-story.com)
+ * @since         0.0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\File;
+
+use MiniAsset\AssetTarget;
+use MiniAsset\File\FileInterface;
+
+/**
+ * Wrapper for targets that are adding to the file list of
+ * another asset target.
+ */
+class Target implements FileInterface
+{
+    private $target;
+    private $compiler;
+
+    public function __construct(AssetTarget $target, $compiler)
+    {
+        $this->target = $target;
+        $this->compiler = $compiler;
+    }
+
+    public function path()
+    {
+        return $this->target->path();
+    }
+
+    public function name()
+    {
+        return $this->target->name();
+    }
+
+    public function contents()
+    {
+        return $this->compiler->build($this->target);
+    }
+
+    public function modifiedTime()
+    {
+        return $this->target->modifiedTime();
+    }
+}

--- a/src/File/Target.php
+++ b/src/File/Target.php
@@ -15,6 +15,7 @@ namespace MiniAsset\File;
 
 use MiniAsset\AssetTarget;
 use MiniAsset\File\FileInterface;
+use MiniAsset\Output\CompilerInterface;
 
 /**
  * Wrapper for targets that are adding to the file list of
@@ -25,7 +26,7 @@ class Target implements FileInterface
     private $target;
     private $compiler;
 
-    public function __construct(AssetTarget $target, $compiler)
+    public function __construct(AssetTarget $target, CompilerInterface $compiler)
     {
         $this->target = $target;
         $this->compiler = $compiler;

--- a/tests/TestCase/AssetConfigTest.php
+++ b/tests/TestCase/AssetConfigTest.php
@@ -91,14 +91,6 @@ class AssetConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('Uglifyjs'), $this->config->filters('js'));
     }
 
-    public function testTargetFilters()
-    {
-        $this->config->addTarget('libs.js', [
-            'filters' => ['Uglifyjs']
-        ]);
-        $this->assertEquals(['Sprockets', 'YuiJs', 'Uglifyjs'], $this->config->targetFilters('libs.js'));
-    }
-
     public function testFiles()
     {
         $result = $this->config->files('libs.js');
@@ -154,6 +146,19 @@ class AssetConfigTest extends \PHPUnit_Framework_TestCase
             $this->config->files('testing-two.js')
         );
         $this->assertTrue($this->config->isThemed('testing-two.js'));
+    }
+
+    public function testRequires()
+    {
+        $this->config->addTarget('testing.js', array(
+            'files' => array('one.js', 'two.js'),
+        ));
+        $this->config->addTarget('child.js', array(
+            'files' => array('one.js', 'two.js'),
+            'require' => 'base.js'
+        ));
+        $this->assertEquals([], $this->config->requires('testing.js'));
+        $this->assertEquals(['base.js'], $this->config->requires('child.js'));
     }
 
     public function testGetExt()

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -56,8 +56,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory->filterRegistry();
     }
 
-
-    public function testCallbackProvider()
+    public function testTargetCallbackProvider()
     {
         $callbacksFile = APP . 'config' . DS . 'callbacks.ini';
         $config = AssetConfig::buildFromIniFile($callbacksFile);
@@ -78,7 +77,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testCallbackProviderAssetOrdering()
+    public function testTargetCallbackProviderAssetOrdering()
     {
         $callbacksFile = APP . 'config' . DS . 'callbacks.ini';
         $config = AssetConfig::buildFromIniFile($callbacksFile);
@@ -111,13 +110,23 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
      * @expectedException RuntimeException
      * @expectedExceptionMessage Callback MiniAsset\Test\Helpers\MyCallbackProvider::invalid() is not callable
      */
-    public function testCallbackProviderNotCallable()
+    public function testTargetCallbackProviderNotCallable()
     {
         $callbacksFile = APP . 'config' . DS . 'callbacks.ini';
         $config = AssetConfig::buildFromIniFile($callbacksFile);
 
         $factory = new Factory($config);
         $target = $factory->target('callbacks_not_callable.js');
+    }
+
+    public function testTargetWithRequiredTargetMissingDependency()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testTargetWithRequiredTarget()
+    {
+        $this->markTestIncomplete();
     }
 
     public function testAssetCollection()

--- a/tests/TestCase/File/GlobTest.php
+++ b/tests/TestCase/File/GlobTest.php
@@ -29,9 +29,10 @@ class GlobTest extends \PHPUnit_Framework_TestCase
     {
         $glob = new Glob(dirname(__FILE__) . DS, '*');
         $files = $glob->files();
-        $this->assertCount(3, $files);
+        $this->assertCount(4, $files);
         $this->assertEquals('GlobTest.php', $files[0]->name());
         $this->assertEquals('LocalTest.php', $files[1]->name());
         $this->assertEquals('RemoteTest.php', $files[2]->name());
+        $this->assertEquals('TargetTest.php', $files[3]->name());
     }
 }

--- a/tests/TestCase/File/TargetTest.php
+++ b/tests/TestCase/File/TargetTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mark Story (http://mark-story.com)
+ * @since         0.0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\Test\TestCase\File;
+
+use MiniAsset\File\Local;
+
+class TargetTest extends \PHPUnit_Framework_TestCase
+{
+    public function testName()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testContents()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testModifiedTime()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testPath()
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/tests/TestCase/File/TargetTest.php
+++ b/tests/TestCase/File/TargetTest.php
@@ -13,27 +13,46 @@
  */
 namespace MiniAsset\Test\TestCase\File;
 
+use MiniAsset\AssetTarget;
 use MiniAsset\File\Local;
+use MiniAsset\File\Target;
 
 class TargetTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+        $this->compiler = $this->getMockBuilder('MiniAsset\Output\CompilerInterface')->getMock();
+
+        $files = [
+            new Local(APP . 'js/classes/base_class_two.js')
+        ];
+        $this->asset = new AssetTarget(TMP . 'all.css', $files);
+        $this->target = new Target($this->asset, $this->compiler);
+    }
+
     public function testName()
     {
-        $this->markTestIncomplete();
+        $this->assertEquals('all.css', $this->target->name());
     }
 
     public function testContents()
     {
-        $this->markTestIncomplete();
+        $this->compiler->expects($this->once())
+            ->method('generate')
+            ->with($this->asset)
+            ->will($this->returnValue('contents'));
+
+        $this->assertEquals('contents', $this->target->contents());
     }
 
     public function testModifiedTime()
     {
-        $this->markTestIncomplete();
+        $this->assertNotNull($this->target->modifiedTime());
     }
 
     public function testPath()
     {
-        $this->markTestIncomplete();
+        $this->assertEquals(TMP . 'all.css', $this->target->path());
     }
 }

--- a/tests/TestCase/Filter/SprocketsTest.php
+++ b/tests/TestCase/Filter/SprocketsTest.php
@@ -112,6 +112,8 @@ TEXT;
 /*!
  this comment will stay
 */
+// Local script
+
 // this comment should be removed
 function test(thing) {
     /* this comment will be removed */
@@ -193,9 +195,10 @@ TEXT;
         ];
         $target = new AssetTarget('test.js', $files);
         $result = $this->filter->getDependencies($target);
-        $this->assertCount(2, $result, 'Should find 2 files.');
+        $this->assertCount(3, $result, 'Should find 3 files.');
         $this->assertEquals('library_file.js', $result[0]->name());
-        $this->assertEquals('another_class.js', $result[1]->name());
+        $this->assertEquals('local_script.js', $result[1]->name());
+        $this->assertEquals('another_class.js', $result[2]->name());
     }
 
     protected function assertTextEquals($expected, $result, $message = '')

--- a/tests/test_files/config/require.ini
+++ b/tests/test_files/config/require.ini
@@ -1,0 +1,21 @@
+[General]
+
+[js]
+cachePath = WEBROOT/cache_js
+paths[] = APP/js
+
+[libs.js]
+files[] = classes/template.js
+filters[] = Sprockets
+
+[middle.js]
+require = libs.js
+files[] = library_file.js
+
+[second.js]
+require = middle.js
+files[] = lots_of_comments.js
+
+[invalid-require.js]
+require = nope.js
+files[] = lots_of_comments.js

--- a/tests/test_files/js/library_file.js
+++ b/tests/test_files/js/library_file.js
@@ -1,6 +1,7 @@
 /*!
  this comment will stay
 */
+//= require "local_script"
 // this comment should be removed
 function test(thing) {
     /* this comment will be removed */

--- a/tests/test_files/js/local_script.js
+++ b/tests/test_files/js/local_script.js
@@ -1,0 +1,1 @@
+// Local script


### PR DESCRIPTION
Add support for intermediary builds via `require`. Intermediary builds allow compiled/minified assets to be included in other assets. This behaviour is different from `extend` in that the _generated_ asset is used, not the source files. Furthermore, the filters attached to the required asset are not applied to the 'child' asset.

Refs #30 
