### PR TITLE
Uglifyjs with sourcemaps option and file list.

### DIFF
--- a/src/Filter/Uglifyjs.php
+++ b/src/Filter/Uglifyjs.php
@@ -39,7 +39,8 @@ class Uglifyjs extends AssetFilter
      * @param string $content Content of the file.
      * @return string
      */
-    public function input($filename, $content) {
+    public function input($filename, $content)
+    {
         $this->files[] = $filename;
         return $content;
     }
@@ -58,10 +59,6 @@ class Uglifyjs extends AssetFilter
             $this->_settings['uglify'] . ' ' .
             $files . ' ' .
             $this->_settings['options'];
-
-        if ($this->_settings['create_map']) {
-            $cmd .= ' ' . $this->_settings['source_map'];
-        }
 
         // $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . ' - ' . $this->_settings['options'];
         $env = array('NODE_PATH' => $this->_settings['node_path']);

--- a/src/Filter/Uglifyjs.php
+++ b/src/Filter/Uglifyjs.php
@@ -33,6 +33,17 @@ class Uglifyjs extends AssetFilter
     );
 
     /**
+     * Input filter.
+     *
+     * @param string $filename Name of the file
+     * @param string $content Content of the file.
+     * @return string
+     */
+    public function input($filename, $content) {
+        $this->files[] = $filename;
+        return $content;
+    }
+    /**
      * Run `uglifyjs` against the output and compress it.
      *
      * @param string $filename Name of the file being generated.
@@ -41,8 +52,19 @@ class Uglifyjs extends AssetFilter
      */
     public function output($filename, $input)
     {
-        $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . ' - ' . $this->_settings['options'];
+        $files = implode(' ', $this->files);
+        $cmd =
+            $this->_settings['node'] . ' ' .
+            $this->_settings['uglify'] . ' ' .
+            $files . ' ' .
+            $this->_settings['options'];
+
+        if ($this->_settings['create_map']) {
+            $cmd .= ' ' . $this->_settings['source_map'];
+        }
+
+        // $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . ' - ' . $this->_settings['options'];
         $env = array('NODE_PATH' => $this->_settings['node_path']);
-        return $this->_runCmd($cmd, $input, $env);
+        return $this->_runCmd($cmd, '', $env);
     }
 }

--- a/src/Filter/Uglifyjs.php
+++ b/src/Filter/Uglifyjs.php
@@ -60,7 +60,6 @@ class Uglifyjs extends AssetFilter
             $files . ' ' .
             $this->_settings['options'];
 
-        // $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . ' - ' . $this->_settings['options'];
         $env = array('NODE_PATH' => $this->_settings['node_path']);
         return $this->_runCmd($cmd, '', $env);
     }


### PR DESCRIPTION
Uglifyjs doesn't create source maps from STDIN, so we need the list of files.

You could put  the domain in the asset_compress.ini like
    `--source-map-url http/yourdomain/cached_js/scripts.js.map`.
And the option to create it.
    `create_map = true`.