### PR TITLE
Added general.timestampPath to define timestamp file location

### DIFF
--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -171,6 +171,10 @@ class AssetConfig
                 }
                 $this->addExtension($section, $values);
             } elseif (strtolower($section) === self::GENERAL) {
+                if (!empty($values['timestampPath'])) {
+                    $path = $this->_replacePathConstants($values['timestampPath']);
+                    $values['timestampPath'] = rtrim($path, '/') . '/';
+                }
                 $this->set(self::GENERAL, $values);
             } elseif (strpos($section, self::FILTER_PREFIX) === 0) {
                 // filter section.

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -89,6 +89,7 @@ class Factory
      */
     public function writer($tmpPath = '')
     {
+        $tmpPath = $tmpPath ?: $this->config->get('general.timestampPath');
         if (!$tmpPath) {
             $tmpPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR;
         }

--- a/tests/TestCase/AssetConfigTest.php
+++ b/tests/TestCase/AssetConfigTest.php
@@ -30,6 +30,7 @@ class AssetConfigTest extends \PHPUnit_Framework_TestCase
         $this->testConfig = $this->_testFiles . 'config' . DS . 'config.ini';
         $this->extendConfig = $this->_testFiles . 'config' . DS . 'extended.ini';
         $this->_themeConfig = $this->_testFiles . 'config' . DS . 'themed.ini';
+        $this->timestampConfig = $this->_testFiles . 'config' . DS . 'timestamp.ini';
 
         $this->config = AssetConfig::buildFromIniFile($this->testConfig);
     }
@@ -263,6 +264,13 @@ class AssetConfigTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->config->general('non-existant');
         $this->assertNull($result);
+    }
+
+    public function testGeneralTimestampPath()
+    {
+        $config = AssetConfig::buildFromIniFile($this->timestampConfig);
+
+        $this->assertSame(WEBROOT . 'timestamp' . DIRECTORY_SEPARATOR, $config->get('general.timestampPath'));
     }
 
     /**

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -30,6 +30,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->pluginFile = APP . 'config' . DS . 'plugins.ini';
         $this->overrideFile = APP . 'config' . DS . 'overridable.local.ini';
         $this->globFile = APP . 'config' . DS . 'glob.ini';
+        $this->timestampFile = APP . 'config' . DS . 'timestamp.ini';
     }
 
     public function testFilterRegistry()
@@ -281,6 +282,23 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             ],
             'path' => TMP,
             'theme' => 'Red'
+        ];
+        $this->assertEquals($expected, $writer->config());
+    }
+
+    public function testWriterWithTimestampPath()
+    {
+        $config = AssetConfig::buildFromIniFile($this->timestampFile);
+        $factory = new Factory($config);
+        $writer = $factory->writer();
+
+        $expected = [
+            'timestamp' => [
+                'js' => true,
+                'css' => false
+            ],
+            'path' => WEBROOT . 'timestamp' . DIRECTORY_SEPARATOR,
+            'theme' => '',
         ];
         $this->assertEquals($expected, $writer->config());
     }

--- a/tests/test_files/config/timestamp.ini
+++ b/tests/test_files/config/timestamp.ini
@@ -1,0 +1,11 @@
+; A mostly empty config file to test timestamp path
+;
+[General]
+writeCache = true
+timestampPath=WEBROOT/timestamp
+
+[js]
+timestamp=true
+
+[libs.js]
+files[] = class.js


### PR DESCRIPTION
In my case, my build server doesn't have access to my tmp directory (cakephp TMP) as it's not mounted during build time. Building assets after the build server isn't an option as it's too late and the infrastructure moves to read-only before deploy.

This option will hopefully allow me to configure a different path for the timestamp file so I can put it somewhere other than the yet-to-be-mounted tmp dir. 

If this looks good and is merged/released, I'll prepare a PR for the cake plugin as it sets the path to to `TMP`.