### PR TITLE
Adding support for UglifyJS2 since Uglifyjs is deprecated.

### DIFF
--- a/src/Filter/Uglifyjs.php
+++ b/src/Filter/Uglifyjs.php
@@ -29,6 +29,7 @@ class Uglifyjs extends AssetFilter
         'node' => '/usr/local/bin/node',
         'uglify' => '/usr/local/bin/uglifyjs',
         'node_path' => '/usr/local/lib/node_modules',
+        'version' => 1,
         'options' => '',
     );
 
@@ -41,7 +42,8 @@ class Uglifyjs extends AssetFilter
      */
     public function output($filename, $input)
     {
-        $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . ' - ' . $this->_settings['options'];
+        $cmdSeparator = $this->_settings['version'] <= 1 ? ' - ' : '';
+        $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . $cmdSeparator . $this->_settings['options'];
         $env = array('NODE_PATH' => $this->_settings['node_path']);
         return $this->_runCmd($cmd, $input, $env);
     }

--- a/src/Filter/Uglifyjs.php
+++ b/src/Filter/Uglifyjs.php
@@ -37,7 +37,7 @@ class Uglifyjs extends AssetFilter
      * Run `uglifyjs` against the output and compress it.
      *
      * @param string $filename Name of the file being generated.
-     * @param string $input Th4 uncompressed contents for $filename.
+     * @param string $input The uncompressed contents for $filename.
      * @return string Compressed contents.
      */
     public function output($filename, $input)

--- a/src/Filter/Uglifyjs.php
+++ b/src/Filter/Uglifyjs.php
@@ -42,8 +42,8 @@ class Uglifyjs extends AssetFilter
      */
     public function output($filename, $input)
     {
-        $cmdSeparator = $this->_settings['version'] <= 1 ? ' - ' : '';
-        $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . $cmdSeparator . $this->_settings['options'];
+        $cmdSep = $this->_settings['version'] <= 1 ? ' - ' : '';
+        $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . $cmdSep . $this->_settings['options'];
         $env = array('NODE_PATH' => $this->_settings['node_path']);
         return $this->_runCmd($cmd, $input, $env);
     }


### PR DESCRIPTION
In this PR I've added support by introducing a new option which tells the version of Uglify being used. I was using uglify-js (UglifyJs2) and could not compile my assets.