### PR TITLE
Handle constant ressources

### DIFF
--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -116,13 +116,15 @@ class AssetConfig
     protected function _addConstants($constants)
     {
         foreach ($constants as $key => $value) {
-            if (is_array($value) || strpos($value, DIRECTORY_SEPARATOR) === false) {
-                continue;
+            if (is_resource($value) === false) {
+                if (is_array($value) || strpos($value, DIRECTORY_SEPARATOR) === false) {
+                    continue;
+                }
+                if ($value !== DIRECTORY_SEPARATOR && !@file_exists($value)) {
+                    continue;
+                }
+                $this->constantMap[$key] = rtrim($value, DIRECTORY_SEPARATOR);
             }
-            if ($value !== DIRECTORY_SEPARATOR && !@file_exists($value)) {
-                continue;
-            }
-            $this->constantMap[$key] = rtrim($value, DIRECTORY_SEPARATOR);
         }
         ksort($this->constantMap);
     }


### PR DESCRIPTION
Somewhere in my application (vendor) some constant ressources where added:
```
$constants = [
	'CHRONOS_SUPPORTS_MICROSECONDS' => true,
	'DS' => '/',
	'STDOUT' => resource,
	'STDERR' => resource,
	'ROOT' => '/var/www/html',
	'APP_DIR' => 'src',
	'APP' => '/var/www/html/src/',
	'CONFIG' => '/var/www/html/config/',
	'WWW_ROOT' => '/var/www/html/webroot/',
	'TESTS' => '/var/www/html/tests/',
	'TMP' => '/var/www/html/tmp/',
	'LOGS' => '/var/www/html/logs/',
	'CACHE' => '/var/www/html/tmp/cache/',
	'CAKE_CORE_INCLUDE_PATH' => '/var/www/html/vendor/cakephp/cakephp',
	'CORE_PATH' => '/var/www/html/vendor/cakephp/cakephp/',
	'CAKE' => '/var/www/html/vendor/cakephp/cakephp/src/',
	'TIME_START' => (float) 1550478356.5377,
	'SECOND' => (int) 1,
	'MINUTE' => (int) 60,
	'HOUR' => (int) 3600,
	'DAY' => (int) 86400,
	'WEEK' => (int) 604800,
	'MONTH' => (int) 2592000,
	'YEAR' => (int) 31536000
]
```
 With this patch they can be handled.