### PR TITLE
`leafo/scssphp` has migrated to `scssphp/scssphp`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "natxet/CssMin": "For using the CssMin filter.",
     "tchwork/jsqueeze": "For using the JSqueeze filter.",
     "tedivm/jshrink": "For using the JShrink filter.",
-    "leafo/scssphp": "For using the ScssPHP filter.",
+    "scssphp/scssphp": "For using the ScssPHP filter.",
     "oyejorge/less.php": "For using the LessDotPHP filter, see https://github.com/oyejorge/less.php",
     "zendframework/diactoros": "The middleware layer relies on zendframework/diactoros."
   }

--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -22,7 +22,7 @@ use ScssPhp\ScssPhp\Compiler;
  *
  * Requires scssphp to be installed via composer.
  *
- * @see http://leafo.net/scssphp
+ * @see https://github.com/scssphp/scssphp
  */
 class ScssPHP extends AssetFilter
 {

--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -15,7 +15,7 @@ namespace MiniAsset\Filter;
 
 use MiniAsset\Filter\AssetFilter;
 use MiniAsset\Filter\CssDependencyTrait;
-use Leafo\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Compiler;
 
 /**
  * Pre-processing filter that adds support for SCSS files.
@@ -40,8 +40,6 @@ class ScssPHP extends AssetFilter
     protected $optionalDependencyPrefix = '_';
 
     /**
-     * Runs `scssc` against any files that match the configured extension.
-     *
      * @param string $filename The name of the input file.
      * @param string $input The content of the file.
      * @throws \Exception
@@ -52,8 +50,8 @@ class ScssPHP extends AssetFilter
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $input;
         }
-        if (!class_exists('Leafo\\ScssPhp\\Compiler')) {
-            throw new \Exception(sprintf('Cannot not load filter class "%s".', 'Leafo\\ScssPhp\\Compiler'));
+        if (!class_exists('ScssPhp\\ScssPhp\\Compiler')) {
+            throw new \Exception(sprintf('Cannot not load filter class "%s".', 'ScssPhp\\ScssPhp\\Compiler'));
         }
         $sc = new Compiler();
         $sc->addImportPath(dirname($filename));


### PR DESCRIPTION
Thankfully everything with the API is the same, and just the namespace and Composer reference needs updating.

The `asset_compress` library already references the updated ScssPHP library in suggested installs: https://github.com/markstory/asset_compress/blob/master/composer.json#L42