### PR TITLE
Fix lying type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "authors": [
     {
       "name": "Mark Story",
-      "homepage": "http://mark-story.com",
+      "homepage": "https://mark-story.com",
       "role": "Author"
     }
   ],
@@ -27,12 +27,12 @@
   },
   "autoload": {
     "psr-4": {
-      "MiniAsset\\": "src"
+      "MiniAsset\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "MiniAsset\\Test\\": "tests"
+      "MiniAsset\\Test\\": "tests/"
     }
   },
   "bin": ["bin/mini_asset"],

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "markstory/mini-asset",
   "description": "An asset compression library. Provides file concatenation and a flexible filter system for preprocessing and minification.",
-  "type": "cakephp-plugin",
+  "type": "library",
   "keywords": ["cakephp", "assets", "minifier", "less", "coffee-script", "sass", "psr7"],
   "homepage": "https://github.com/markstory/mini-asset",
   "license": "MIT",


### PR DESCRIPTION
The lying type is making IdeHelper detect this as cake plugin and thus recommend this for autocomplete in Application addPlugin() etc. :) thats not so good.

Also vendor/cakephp-plugins.php contains this wrongly:

    'MiniAsset' => $baseDir . '/vendor/markstory/mini-asset/',