### PR TITLE
Add paths to ScssPHP import paths

### DIFF
--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -30,6 +30,7 @@ class ScssPHP extends AssetFilter
 
     protected $_settings = array(
         'ext' => '.scss',
+        'paths' => [],
     );
 
     /**

--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -55,6 +55,9 @@ class ScssPHP extends AssetFilter
         }
         $sc = new Compiler();
         $sc->addImportPath(dirname($filename));
+        foreach ($this->_settings['paths'] as $path) {
+            $sc->addImportPath($path);
+        }
         return $sc->compile($input);
     }
 }


### PR DESCRIPTION
I need the paths in the configuration to be imported in ScssPHP so I can use the CSS framework files from my project. The current implementation adds just the path the current file is in, but I'm not directly loading the CSS framework in asset_compress, instead I'm importing them in my scss files.