### PR TITLE
Allow SVG filters

### DIFF
--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -637,7 +637,7 @@ class AssetConfig
      */
     public function extensions()
     {
-        return ['css', 'js'];
+        return self::$_extensionTypes;
     }
 
     /**

--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -65,7 +65,7 @@ class AssetConfig
      * @var array
      */
     protected static $_extensionTypes = array(
-        'js', 'css', 'png', 'gif', 'jpeg'
+        'js', 'css', 'png', 'gif', 'jpeg', 'svg'
     );
 
     /**


### PR DESCRIPTION
This pull request solves markstory/asset_compress#351.

I had to make a change to `AssetConfig::extensions()` to be able to use svg in my asset_compress.ini. Please let me know if that’s okay :relaxed: 