### PR TITLE
Add import paths to ScssFilter

### DIFF
--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -442,10 +442,9 @@ class AssetConfig
                 return $result;
             }
         }
-        $this->_filters[$filter] = array_map(
-            [$this, '_replacePathConstants'],
-            $settings
-        );
+
+        // array_map_recursive
+        $this->_filters[$filter] = filter_var($settings, \FILTER_CALLBACK, ['options' => [$this, '_replacePathConstants']]);
     }
 
     /**

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -32,6 +32,7 @@ trait CssDependencyTrait
      */
     public function getDependencies(AssetTarget $target, array $paths = [])
     {
+        $prefixedName = '';
         $children = [];
         $hasPrefix = (property_exists($this, 'optionalDependencyPrefix') &&
             !empty($this->optionalDependencyPrefix));

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -30,7 +30,7 @@ trait CssDependencyTrait
     /**
      * {@inheritDoc}
      */
-    public function getDependencies(AssetTarget $target)
+    public function getDependencies(AssetTarget $target, array $paths = [])
     {
         $children = [];
         $hasPrefix = (property_exists($this, 'optionalDependencyPrefix') &&
@@ -55,7 +55,14 @@ trait CssDependencyTrait
                 }
                 $deps[] = $name;
                 if ($hasPrefix) {
-                    $deps[] = $this->_prependPrefixToFilename($name);
+                    $prefixedName = $this->_prependPrefixToFilename($name);
+                    $deps[] = $prefixedName;
+                }
+                foreach ($paths as $path) {
+                    $deps[] = $path . DIRECTORY_SEPARATOR . $name;
+                    if ($hasPrefix) {
+                        $deps[] = $path . DIRECTORY_SEPARATOR . $prefixedName;
+                    }
                 }
             }
             foreach ($deps as $import) {

--- a/src/Filter/ScssFilter.php
+++ b/src/Filter/ScssFilter.php
@@ -25,7 +25,9 @@ use MiniAsset\Filter\CssDependencyTrait;
  */
 class ScssFilter extends AssetFilter
 {
-    use CssDependencyTrait;
+    use CssDependencyTrait {
+        getDependencies as getCssDependencies;
+    }
 
     protected $_settings = array(
         'ext' => '.scss',
@@ -40,6 +42,11 @@ class ScssFilter extends AssetFilter
      * @var string
      */
     protected $optionalDependencyPrefix = '_';
+
+    public function getDependencies($target)
+    {
+        return $this->getCssDependencies($target, $this->_settings['imports']);
+    }
 
     /**
      * Runs SCSS compiler against any files that match the configured extension.

--- a/src/Filter/ScssFilter.php
+++ b/src/Filter/ScssFilter.php
@@ -31,7 +31,7 @@ class ScssFilter extends AssetFilter
         'ext' => '.scss',
         'sass' => '/usr/bin/sass',
         'path' => '/usr/bin',
-        'paths' => [],
+        'imports' => [],
     );
 
     /**
@@ -54,7 +54,11 @@ class ScssFilter extends AssetFilter
             return $input;
         }
         $filename = preg_replace('/ /', '\\ ', $filename);
-        $bin = $this->_settings['sass'] . ' ' . $filename;
+        $cmd = $this->_settings['sass'];
+        foreach ($this->_settings['imports'] as $path) {
+            $cmd .= " -I \"{$path}\"";
+        }
+        $bin = $cmd . ' ' . $filename;
         $return = $this->_runCmd($bin, '', array('PATH' => $this->_settings['path']));
         return $return;
     }

--- a/src/Filter/ScssFilter.php
+++ b/src/Filter/ScssFilter.php
@@ -56,7 +56,7 @@ class ScssFilter extends AssetFilter
         $filename = preg_replace('/ /', '\\ ', $filename);
         $cmd = $this->_settings['sass'];
         foreach ($this->_settings['imports'] as $path) {
-            $cmd .= " -I \"{$path}\"";
+            $cmd .= ' -I ' . escapeshellarg($path);
         }
         $bin = $cmd . ' ' . $filename;
         $return = $this->_runCmd($bin, '', array('PATH' => $this->_settings['path']));

--- a/tests/TestCase/Filter/ScssFilterTest.php
+++ b/tests/TestCase/Filter/ScssFilterTest.php
@@ -70,4 +70,22 @@ class ScssFilterTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertEquals('colors.scss', $result[0]->name());
     }
+
+    public function testImports()
+    {
+        $this->filter->settings([
+            'paths' => [$this->_cssDir],
+            'imports' => [$this->_cssDir . DIRECTORY_SEPARATOR . 'reset'],
+        ]);
+        $files = [
+            new Local($this->_cssDir . 'test_imports.scss')
+        ];
+        $target = new AssetTarget('test.css', $files);
+        $result = $this->filter->getDependencies($target);
+
+        $this->assertCount(3, $result);
+        $this->assertEquals('colors.scss', $result[0]->name());
+        $this->assertEquals('_utilities.scss', $result[1]->name());
+        $this->assertEquals('_reset.scss', $result[2]->name());
+    }
 }

--- a/tests/test_files/css/test_imports.scss
+++ b/tests/test_files/css/test_imports.scss
@@ -1,0 +1,63 @@
+@import 'colors';
+@import 'utilities';
+@import 'reset';
+
+.content-navigation {
+  border-color: $blue;
+  color:
+    darken($blue, 9%);
+}
+
+.border {
+  padding: $margin / 2;
+  margin: $margin / 2;
+  border-color: $blue;
+}
+
+table.hl {
+  margin: 2em 0;
+  td.ln {
+    text-align: right;
+  }
+}
+
+li {
+  font: {
+    family: serif;
+    weight: bold;
+    size: 1.2em;
+  }
+}
+
+@mixin table-base {
+  th {
+    text-align: center;
+    font-weight: bold;
+  }
+  td, th {padding: 2px}
+}
+
+@mixin left($dist) {
+  float: left;
+  margin-left: $dist;
+}
+
+#data {
+  @include left(10px);
+  @include table-base;
+}
+
+
+.error {
+  border: 1px #f00;
+  background: #fdd;
+}
+.error.intrusion {
+  font-size: 1.3em;
+  font-weight: bold;
+}
+
+.badError {
+  @extend .error;
+  border-width: 3px;
+}


### PR DESCRIPTION
This PR allows setting `sass` compiler import paths. This way I can import scss files from 3rd party projects.

I had to make a change to allow using custom settings of type array in the filter settings section. I could have solved it with a list of paths chained with semicolons but it was a departure from the style in the config file.