### PR TITLE
Add generic pipe filters

### DIFF
--- a/src/Filter/AssetFilter.php
+++ b/src/Filter/AssetFilter.php
@@ -83,6 +83,16 @@ class AssetFilter implements FilterInterface
     }
 
     /**
+     * Overloaded in filters that can't handle dependencies
+     *
+     * @return boolean True when the filter supports dependencies
+     */
+    public function hasDependencies()
+    {
+        return true;
+    }
+
+    /**
      * Run the compressor command and get the output
      *
      * @param  string $cmd     The command to run.

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -59,4 +59,11 @@ interface FilterInterface
      * @return array An array of MiniAsset\File\Local objects.
      */
     public function getDependencies(AssetTarget $target);
+
+    /**
+     * Returns a boolean whether the filter supports dependencies.
+     *
+     * @return boolean True when the filter supports dependencies
+     */
+    public function hasDependencies();
 }

--- a/src/Filter/PipeInputFilter.php
+++ b/src/Filter/PipeInputFilter.php
@@ -26,11 +26,20 @@ class PipeInputFilter extends AssetFilter
         getDependencies as getCssDependencies;
     }
 
+    /**
+     * Settings for PipeInputFilter
+     *
+     * - `ext` File extension used by the filter
+     * - `dependencies` Set to true to calculate SCSS/LESS dependencies
+     * - `optional_dependency_prefix` Filename prefix for dependencies or false
+     * - `command` Command to run the file through
+     * - `path` Sets PATH environment variable
+     */
     protected $_settings = array(
         'ext' => '.css',
-        'command' => '/bin/cat',
-        'dependencies' => true,
+        'dependencies' => false,
         'optional_dependency_prefix' => false,
+        'command' => '/bin/cat',
         'path' => '/bin',
     );
 

--- a/src/Filter/PipeInputFilter.php
+++ b/src/Filter/PipeInputFilter.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mark Story (http://mark-story.com)
+ * @since         0.0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\Filter;
+
+use MiniAsset\Filter\AssetFilter;
+use MiniAsset\Filter\CssDependencyTrait;
+
+/**
+ * Pre-processing filter that adds support for command pipes
+ */
+class PipeInputFilter extends AssetFilter
+{
+    use CssDependencyTrait {
+        getDependencies as getCssDependencies;
+    }
+
+    protected $_settings = array(
+        'ext' => '.css',
+        'command' => '/bin/cat',
+        'dependencies' => 'none', // none, css, other
+        'optional_dependency_prefix' => false,
+        'path' => '/bin',
+    );
+
+    /**
+     * It will use prefixed files if they exist.
+     *
+     * @var string
+     */
+    protected $optionalDependencyPrefix = null;
+
+    public function getDependencies(\MiniAsset\AssetTarget $file)
+    {
+        if ($this->_settings['dependencies'] !== 'none' && $this->_settings['dependencies'] !== 'css') {
+            return false;
+        }
+
+        if ($this->_settings['dependencies'] === 'css') {
+            $this->optionalDependencyPrefix = $this->_settings['optional_dependency_prefix'];
+
+            return $this->getCssDependencies($file);
+        }
+
+        return [];
+    }
+
+    /**
+     * Runs command against any files that match the configured extension.
+     *
+     * @param string $filename The name of the input file.
+     * @param string $input The content of the file.
+     * @return string
+     */
+    public function input($filename, $input)
+    {
+        if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
+            return $input;
+        }
+        $filename = preg_replace('/ /', '\\ ', $filename);
+        $bin = $this->_settings['command'] . ' ' . $filename;
+        $return = $this->_runCmd($bin, '', array('PATH' => $this->_settings['path']));
+
+        return $return;
+    }
+}

--- a/src/Filter/PipeInputFilter.php
+++ b/src/Filter/PipeInputFilter.php
@@ -29,7 +29,7 @@ class PipeInputFilter extends AssetFilter
     protected $_settings = array(
         'ext' => '.css',
         'command' => '/bin/cat',
-        'dependencies' => 'none', // none, css, other
+        'dependencies' => true,
         'optional_dependency_prefix' => false,
         'path' => '/bin',
     );
@@ -41,13 +41,14 @@ class PipeInputFilter extends AssetFilter
      */
     protected $optionalDependencyPrefix = null;
 
+    public function hasDependencies()
+    {
+        return $this->_settings['dependencies'];
+    }
+
     public function getDependencies(AssetTarget $file)
     {
-        if ($this->_settings['dependencies'] !== 'none' && $this->_settings['dependencies'] !== 'css') {
-            return false;
-        }
-
-        if ($this->_settings['dependencies'] === 'css') {
+        if ($this->_settings['dependencies']) {
             $this->optionalDependencyPrefix = $this->_settings['optional_dependency_prefix'];
 
             return $this->getCssDependencies($file);

--- a/src/Filter/PipeInputFilter.php
+++ b/src/Filter/PipeInputFilter.php
@@ -68,7 +68,7 @@ class PipeInputFilter extends AssetFilter
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $input;
         }
-        $filename = preg_replace('/ /', '\\ ', $filename);
+        $filename = escapeshellarg($filename);
         $bin = $this->_settings['command'] . ' ' . $filename;
         $return = $this->_runCmd($bin, '', array('PATH' => $this->_settings['path']));
 

--- a/src/Filter/PipeInputFilter.php
+++ b/src/Filter/PipeInputFilter.php
@@ -13,6 +13,7 @@
  */
 namespace MiniAsset\Filter;
 
+use MiniAsset\AssetTarget;
 use MiniAsset\Filter\AssetFilter;
 use MiniAsset\Filter\CssDependencyTrait;
 
@@ -40,7 +41,7 @@ class PipeInputFilter extends AssetFilter
      */
     protected $optionalDependencyPrefix = null;
 
-    public function getDependencies(\MiniAsset\AssetTarget $file)
+    public function getDependencies(AssetTarget $file)
     {
         if ($this->_settings['dependencies'] !== 'none' && $this->_settings['dependencies'] !== 'css') {
             return false;

--- a/src/Filter/PipeOutputFilter.php
+++ b/src/Filter/PipeOutputFilter.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mark Story (http://mark-story.com)
+ * @since         0.0.1
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\Filter;
+
+use MiniAsset\Filter\AssetFilter;
+
+/**
+ * Output pipe processor
+ */
+class PipeOutputFilter extends AssetFilter
+{
+
+    /**
+     * Settings for PipeOutputFilter
+     *
+     * - `command` Command to execute
+     */
+    protected $_settings = array(
+        'command' => '/bin/cat',
+        'path' => '/bin',
+    );
+
+    /**
+     * Run command against the output and compress it.
+     *
+     * @param string $filename Name of the file being generated.
+     * @param string $input The raw contents for $filename.
+     * @return string Processed contents.
+     */
+    public function output($filename, $input)
+    {
+        $cmd = $this->_settings['command'];
+
+        return $this->_runCmd($cmd, $input, array('PATH' => $this->_settings['path']));
+    }
+}

--- a/src/Output/FreshTrait.php
+++ b/src/Output/FreshTrait.php
@@ -90,11 +90,10 @@ trait FreshTrait
 
         $filters = $this->filterRegistry->collection($target);
         foreach ($filters->filters() as $filter) {
-            $dependencies = $filter->getDependencies($target);
-            if ($dependencies === false) {
+            if (!$filter->hasDependencies()) {
                 return false;
             }
-            foreach ($dependencies as $child) {
+            foreach ($filter->getDependencies($target) as $child) {
                 $time = $child->modifiedTime();
                 if ($time >= $buildTime) {
                     return false;

--- a/src/Output/FreshTrait.php
+++ b/src/Output/FreshTrait.php
@@ -90,7 +90,11 @@ trait FreshTrait
 
         $filters = $this->filterRegistry->collection($target);
         foreach ($filters->filters() as $filter) {
-            foreach ($filter->getDependencies($target) as $child) {
+            $dependencies = $filter->getDependencies($target);
+            if ($dependencies === false) {
+                return false;
+            }
+            foreach ($dependencies as $child) {
                 $time = $child->modifiedTime();
                 if ($time >= $buildTime) {
                     return false;

--- a/tests/TestCase/Filter/PipeInputFilterTest.php
+++ b/tests/TestCase/Filter/PipeInputFilterTest.php
@@ -42,10 +42,10 @@ class PipeInputFilterTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function testGetDependenciesNone()
+    public function testGetDependenciesFalse()
     {
         $this->filter->settings(array(
-            'dependencies' => 'none',
+            'dependencies' => false,
             'optional_dependency_prefix' => false,
         ));
 
@@ -58,10 +58,10 @@ class PipeInputFilterTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    public function testGetDependencies()
+    public function testGetDependenciesTrue()
     {
         $this->filter->settings(array(
-            'dependencies' => 'css',
+            'dependencies' => true,
             'optional_dependency_prefix' => '_',
         ));
 
@@ -77,26 +77,10 @@ class PipeInputFilterTest extends TestCase
         $this->assertEquals('_reset.scss', $result[2]->name());
     }
 
-    public function testGetDependenciesAlwaysRun()
-    {
-        $this->filter->settings(array(
-            'dependencies' => 'other',
-            'optional_dependency_prefix' => false,
-        ));
-
-        $files = [
-            new Local($this->_cssDir . 'test.scss')
-        ];
-        $target = new AssetTarget('test.css', $files);
-        $result = $this->filter->getDependencies($target);
-
-        $this->assertFalse($result);
-    }
-
     public function testGetDependenciesMissingDependency()
     {
         $this->filter->settings(array(
-            'dependencies' => 'css',
+            'dependencies' => true,
             'optional_dependency_prefix' => '_',
         ));
 

--- a/tests/TestCase/Filter/PipeInputFilterTest.php
+++ b/tests/TestCase/Filter/PipeInputFilterTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Mark Story (http://mark-story.com)
+ * @since     0.0.1
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\Test\TestCase\Filter;
+
+use MiniAsset\AssetTarget;
+use MiniAsset\File\Local;
+use MiniAsset\Filter\PipeInputFilter;
+use PHPUnit\Framework\TestCase;
+
+class PipeInputFilterTest extends TestCase
+{
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->_cssDir = APP . 'css' . DS;
+        $this->filter = new PipeInputFilter();
+        $this->filter->settings([
+            'paths' => [$this->_cssDir],
+            'ext' => '.scss',
+        ]);
+    }
+
+    public function testParsing()
+    {
+        $this->filter->settings(array('command' => '/bin/cat'));
+
+        $content = file_get_contents($this->_cssDir . 'test.scss');
+        $result = $this->filter->input($this->_cssDir . 'test.scss', $content);
+        $expected = file_get_contents($this->_cssDir . 'test.scss');
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetDependenciesNone()
+    {
+        $this->filter->settings(array(
+            'dependencies' => 'none',
+            'optional_dependency_prefix' => false,
+        ));
+
+        $files = [
+            new Local($this->_cssDir . 'test.scss')
+        ];
+        $target = new AssetTarget('test.css', $files);
+        $result = $this->filter->getDependencies($target);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testGetDependencies()
+    {
+        $this->filter->settings(array(
+            'dependencies' => 'css',
+            'optional_dependency_prefix' => '_',
+        ));
+
+        $files = [
+            new Local($this->_cssDir . 'test.scss')
+        ];
+        $target = new AssetTarget('test.css', $files);
+        $result = $this->filter->getDependencies($target);
+
+        $this->assertCount(3, $result);
+        $this->assertEquals('colors.scss', $result[0]->name());
+        $this->assertEquals('_utilities.scss', $result[1]->name());
+        $this->assertEquals('_reset.scss', $result[2]->name());
+    }
+
+    public function testGetDependenciesAlwaysRun()
+    {
+        $this->filter->settings(array(
+            'dependencies' => 'other',
+            'optional_dependency_prefix' => false,
+        ));
+
+        $files = [
+            new Local($this->_cssDir . 'test.scss')
+        ];
+        $target = new AssetTarget('test.css', $files);
+        $result = $this->filter->getDependencies($target);
+
+        $this->assertFalse($result);
+    }
+
+    public function testGetDependenciesMissingDependency()
+    {
+        $this->filter->settings(array(
+            'dependencies' => 'css',
+            'optional_dependency_prefix' => '_',
+        ));
+
+        $files = [
+            new Local($this->_cssDir . 'broken.scss')
+        ];
+        $target = new AssetTarget('test.css', $files);
+        $result = $this->filter->getDependencies($target);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('colors.scss', $result[0]->name());
+    }
+}

--- a/tests/TestCase/Filter/PipeOutputFilterTest.php
+++ b/tests/TestCase/Filter/PipeOutputFilterTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * MiniAsset
+ * Copyright (c) Mark Story (http://mark-story.com)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Mark Story (http://mark-story.com)
+ * @since     0.0.1
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MiniAsset\Test\TestCase\Filter;
+
+use MiniAsset\Filter\PipeOutputFilter;
+use PHPUnit\Framework\TestCase;
+
+class PipeOutputFilterTest extends TestCase
+{
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->_cssDir = APP . 'css' . DS;
+        $this->filter = new PipeOutputFilter();
+    }
+
+    public function testOutput()
+    {
+        $content = file_get_contents($this->_cssDir . 'unminified.css');
+        $result = $this->filter->output($this->_cssDir . 'unminified.css', $content);
+        $expected = file_get_contents($this->_cssDir . 'unminified.css');
+        $this->assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
There's an input and an output filter that can be configured to execute an external command passing the file as a parameter. I've called them pipes although I'm not using system pipes.

In the input filter, the `dependencies` setting changes how dependencies are handled. We can choose not having dependencies calculated but use the source file timestamp (none), use CSS dependency calculation (css), or always run the filter (other).