### PR TITLE
Use import paths for calculation of dependencies

### DIFF
--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -26,7 +26,9 @@ use ScssPhp\ScssPhp\Compiler;
  */
 class ScssPHP extends AssetFilter
 {
-    use CssDependencyTrait;
+    use CssDependencyTrait {
+        getDependencies as getCssDependencies;
+    }
 
     protected $_settings = array(
         'ext' => '.scss',
@@ -39,6 +41,11 @@ class ScssPHP extends AssetFilter
      * @var string
      */
     protected $optionalDependencyPrefix = '_';
+
+    public function getDependencies($target)
+    {
+        return $this->getCssDependencies($target, $this->_settings['imports']);
+    }
 
     /**
      * @param  string $filename The name of the input file.

--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -30,7 +30,7 @@ class ScssPHP extends AssetFilter
 
     protected $_settings = array(
         'ext' => '.scss',
-        'paths' => [],
+        'imports' => [],
     );
 
     /**
@@ -56,7 +56,7 @@ class ScssPHP extends AssetFilter
         }
         $sc = new Compiler();
         $sc->addImportPath(dirname($filename));
-        foreach ($this->_settings['paths'] as $path) {
+        foreach ($this->_settings['imports'] as $path) {
             $sc->addImportPath($path);
         }
         return $sc->compile($input);


### PR DESCRIPTION
The `paths` setting has been changed to `imports` for consistency with `ScssFilter`.