### PR TITLE
Remove targets other than js and css, too

### DIFF
--- a/src/Cli/ClearTask.php
+++ b/src/Cli/ClearTask.php
@@ -71,15 +71,10 @@ class ClearTask extends BaseTask
             $this->cli->err('<red>No build targets defined</red>.');
             return 1;
         }
-        $targets = array_map(
-            function ($target) {
-                return $target->name();
-            },
-            iterator_to_array($assets)
-        );
 
-        $this->_clearPath($config->cachePath('js'), $targets);
-        $this->_clearPath($config->cachePath('css'), $targets);
+        foreach (iterator_to_array($assets) as $target) {
+            $this->_clearPath($target->outputDir() . DS, [$target->name()]);
+        }
         $this->cli->out('<green>Complete</green>');
 
         return 0;

--- a/src/Cli/ClearTask.php
+++ b/src/Cli/ClearTask.php
@@ -73,7 +73,7 @@ class ClearTask extends BaseTask
         }
 
         foreach (iterator_to_array($assets) as $target) {
-            $this->_clearPath($target->outputDir() . DS, [$target->name()]);
+            $this->_clearPath($target->outputDir() . DIRECTORY_SEPARATOR, [$target->name()]);
         }
         $this->cli->out('<green>Complete</green>');
 

--- a/tests/TestCase/Cli/ClearTaskTest.php
+++ b/tests/TestCase/Cli/ClearTaskTest.php
@@ -38,6 +38,7 @@ class ClearTaskTest extends TestCase
 
         mkdir(TMP . 'cache_js');
         mkdir(TMP . 'cache_css');
+        mkdir(TMP . 'cache_svg');
     }
 
     public function tearDown(): void
@@ -45,6 +46,7 @@ class ClearTaskTest extends TestCase
         parent::tearDown();
         $this->rmdir(TMP . 'cache_js');
         $this->rmdir(TMP . 'cache_css');
+        $this->rmdir(TMP . 'cache_svg');
     }
 
     /**
@@ -84,7 +86,8 @@ class ClearTaskTest extends TestCase
             TMP . 'cache_css/all.css',
             TMP . 'cache_css/all.v12354.css',
             TMP . 'cache_js/libs.js',
-            TMP . 'cache_js/libs.v12354.js'
+            TMP . 'cache_js/libs.v12354.js',
+            TMP . 'cache_svg/foo.bar.svg',
         ];
         foreach ($files as $file) {
             touch($file);

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -196,10 +196,11 @@ class FactoryTest extends TestCase
         $factory = new Factory($config);
         $collection = $factory->assetCollection();
 
-        $this->assertCount(3, $collection);
+        $this->assertCount(4, $collection);
         $this->assertTrue($collection->contains('libs.js'));
         $this->assertTrue($collection->contains('foo.bar.js'));
         $this->assertTrue($collection->contains('all.css'));
+        $this->assertTrue($collection->contains('foo.bar.svg'));
 
         $asset = $collection->get('libs.js');
         $this->assertCount(2, $asset->files(), 'Not enough files');

--- a/tests/test_files/config/integration.ini
+++ b/tests/test_files/config/integration.ini
@@ -19,3 +19,10 @@ paths[] = APP/css/
 
 [all.css]
 files[] = nav.css
+
+[svg]
+cachePath = WEBROOT/cache_svg
+paths[] = APP/svg/**
+
+[foo.bar.svg]
+files[] = ellipse.svg

--- a/tests/test_files/svg/ellipse.svg
+++ b/tests/test_files/svg/ellipse.svg
@@ -1,0 +1,6 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+    <ellipse cx="50" cy="25" rx="50" ry="25" style="fill:blue;"/>
+</svg>


### PR DESCRIPTION
Backport of markstory/asset_compress#353 into mini-asset.