### PR TITLE
Fix Content-Type of SVG when handled by middleware

### DIFF
--- a/src/Middleware/AssetMiddleware.php
+++ b/src/Middleware/AssetMiddleware.php
@@ -85,7 +85,8 @@ class AssetMiddleware
     {
         $types = [
             'css' => 'application/css',
-            'js' => 'application/javascript'
+            'js' => 'application/javascript',
+            'svg' => 'image/svg+xml',
         ];
         return isset($types[$ext]) ? $types[$ext] : 'application/octet-stream';
     }

--- a/tests/TestCase/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AssetMiddlewareTest.php
@@ -125,4 +125,36 @@ class AssetMiddlewareTest extends TestCase
         $this->assertSame(200, $res->getStatusCode(), 'Is 200 on success');
         $this->assertContains('#nav {', '' . $res->getBody(), 'Looks like CSS.');
     }
+
+    public function contentTypesProvider()
+    {
+        return [
+            ['/assets/libs.js', 'application/javascript'],
+            ['/assets/all.css', 'application/css'],
+            ['/assets/foo.bar.svg', 'image/svg+xml'],
+        ];
+    }
+
+    /**
+     * test returned content types
+     *
+     * @dataProvider contentTypesProvider
+     * @return void
+     */
+    public function testBuildFileContentTypes($uri, $expected)
+    {
+        $request = ServerRequestFactory::fromGlobals(
+            [
+            'REQUEST_URI' => $uri
+            ]
+        );
+
+        $response = new Response();
+        $next = function ($req, $res) {
+            return $res;
+        };
+        $res = $this->middleware->__invoke($request, $response, $next);
+
+        $this->assertEquals($expected, $res->getHeaderLine('Content-Type'));
+    }
 }


### PR DESCRIPTION
Backport of markstory/asset_compress#354 into mini-asset.