### PR TITLE
Test improvements for PHPUnit, composer and PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /coverage
 /composer.lock
 /.sass-cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.2
+  - 7.3
   - 7.4
 
 matrix:
@@ -19,7 +20,7 @@ before_script:
 
 install:
   - composer self-update
-  - composer install --prefer-dist --no-interaction --dev
+  - composer install --prefer-dist --no-interaction
   - if [[ $CHECKS = 1 ]]; then composer stan-setup; fi
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require-dev": {
     "squizlabs/php_codesniffer": "*",
     "laminas/laminas-diactoros": "~2.0",
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/TestCase/AssetCollectionTest.php
+++ b/tests/TestCase/AssetCollectionTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 
 class AssetCollectionTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $config = new AssetConfig([]);

--- a/tests/TestCase/AssetConfigTest.php
+++ b/tests/TestCase/AssetConfigTest.php
@@ -15,6 +15,7 @@ namespace MiniAsset\Test\TestCase;
 
 use MiniAsset\AssetConfig;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class AssetConfigTest extends TestCase
 {
@@ -24,7 +25,7 @@ class AssetConfigTest extends TestCase
      *
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_testFiles = APP;
@@ -51,7 +52,7 @@ class AssetConfigTest extends TestCase
     public function testBuildFromIniFile()
     {
         $config = AssetConfig::buildFromIniFile($this->testConfig);
-        $this->assertEquals(1, $config->get('js.timestamp'));
+        $this->assertSame('1', $config->get('js.timestamp'));
         $this->assertEquals(1, $config->general('writeCache'));
         $this->assertEquals(filemtime($this->testConfig), $config->modifiedTime());
     }
@@ -69,12 +70,11 @@ class AssetConfigTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage Configuration file "/bogus" was not found.
-     */
     public function testExceptionOnBogusFile()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Configuration file "/bogus" was not found.');
+
         AssetConfig::buildFromIniFile('/bogus');
     }
 
@@ -307,7 +307,7 @@ class AssetConfigTest extends TestCase
         $this->assertEquals('', $result);
 
         $result = $this->config->theme('red');
-        $this->assertEquals('', $result);
+        $this->assertNull($result);
 
         $result = $this->config->theme();
         $this->assertEquals('red', $result);

--- a/tests/TestCase/AssetScannerTest.php
+++ b/tests/TestCase/AssetScannerTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class AssetScannerTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_testFiles = APP;

--- a/tests/TestCase/AssetTargetTest.php
+++ b/tests/TestCase/AssetTargetTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class AssetTargetTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->target = new AssetTarget(APP . 'example.js');

--- a/tests/TestCase/Cli/BuildTaskTest.php
+++ b/tests/TestCase/Cli/BuildTaskTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 class BuildTaskTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $cli = $this->getMockBuilder('League\CLImate\CLImate')
@@ -40,7 +40,7 @@ class BuildTaskTest extends TestCase
         mkdir(TMP . 'cache_css');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->rmdir(TMP . 'cache_js');

--- a/tests/TestCase/Cli/ClearTaskTest.php
+++ b/tests/TestCase/Cli/ClearTaskTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 class ClearTaskTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $cli = $this->getMockBuilder('League\CLImate\CLImate')
@@ -41,7 +41,7 @@ class ClearTaskTest extends TestCase
         mkdir(TMP . 'cache_svg');
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->rmdir(TMP . 'cache_js');

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -16,10 +16,11 @@ namespace MiniAsset;
 use MiniAsset\AssetConfig;
 use MiniAsset\Factory;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class FactoryTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -46,24 +47,22 @@ class FactoryTest extends TestCase
         $this->assertEquals('/path/to/uglify-js', $filter->settings()['path']);
     }
 
-    /**
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage Cannot load filter "Derp"
-     */
     public function testFilterRegistryMissingFilter()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot load filter "Derp"');
+
         $this->config->filters('js', ['Derp']);
         $this->config->filterConfig('Derp', ['path' => '/test']);
         $factory = new Factory($this->config);
         $factory->filterRegistry();
     }
 
-    /**
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage The target named 'not-there.js' does not exist.
-     */
     public function testTargetMissing()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The target named \'not-there.js\' does not exist.');
+
         $factory = new Factory($this->config);
         $factory->target('not-there.js');
     }
@@ -118,25 +117,23 @@ class FactoryTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage Callback MiniAsset\Test\Helpers\MyCallbackProvider::invalid() is not callable
-     */
     public function testTargetCallbackProviderNotCallable()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Callback MiniAsset\Test\Helpers\MyCallbackProvider::invalid() is not callable');
+
         $callbacksFile = APP . 'config' . DS . 'callbacks.ini';
         $config = AssetConfig::buildFromIniFile($callbacksFile);
 
         $factory = new Factory($config);
-        $target = $factory->target('callbacks_not_callable.js');
+        $factory->target('callbacks_not_callable.js');
     }
 
-    /**
-     * @expectedException        RuntimeException
-     * @expectedExceptionMessage The target named 'nope.js' does not exist.
-     */
     public function testTargetWithRequiredTargetMissingDependency()
     {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The target named \'nope.js\' does not exist.');
+
         $requireFile = APP . 'config' . DS . 'require.ini';
         $config = AssetConfig::buildFromIniFile($requireFile);
 
@@ -176,9 +173,9 @@ class FactoryTest extends TestCase
         $this->assertEquals('middle.js', $middle->name());
 
         $contents = $middle->contents();
-        $this->assertContains('var BaseClass', $contents, 'No baseclass, sprockets not applied');
-        $this->assertContains('var Template', $contents);
-        $this->assertContains(
+        $this->assertStringContainsString('var BaseClass', $contents, 'No baseclass, sprockets not applied');
+        $this->assertStringContainsString('var Template', $contents);
+        $this->assertStringContainsString(
             '//= require "local_script"',
             $contents,
             'Sprockets should not be applied to intermediate build files'

--- a/tests/TestCase/File/GlobTest.php
+++ b/tests/TestCase/File/GlobTest.php
@@ -15,15 +15,15 @@ namespace MiniAsset\Test\TestCase\File;
 
 use MiniAsset\File\Glob;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class GlobTest extends TestCase
 {
-    /**
-     * @expectedException RuntimeException
-     */
     public function testErrorOnInvalidBasePath()
     {
-        $file = new Glob('/invalid/', '*');
+        $this->expectException(RuntimeException::class);
+
+        new Glob('/invalid/', '*');
     }
 
     public function testFiles()

--- a/tests/TestCase/File/LocalTest.php
+++ b/tests/TestCase/File/LocalTest.php
@@ -15,15 +15,15 @@ namespace MiniAsset\Test\TestCase\File;
 
 use MiniAsset\File\Local;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class LocalTest extends TestCase
 {
-    /**
-     * @expectedException RuntimeException
-     */
     public function testErrorOnInvalidFile()
     {
-        $file = new Local('/invalid');
+        $this->expectException(RuntimeException::class);
+
+        new Local('/invalid');
     }
 
     public function testName()
@@ -35,7 +35,7 @@ class LocalTest extends TestCase
     public function testContents()
     {
         $file = new Local(__FILE__);
-        $this->assertContains('LocalTest extends TestCase', $file->contents());
+        $this->assertStringContainsString('LocalTest extends TestCase', $file->contents());
     }
 
     public function testModifiedTime()

--- a/tests/TestCase/File/RemoteTest.php
+++ b/tests/TestCase/File/RemoteTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class RemoteTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $file = file_get_contents('http://google.com');
@@ -36,7 +36,7 @@ class RemoteTest extends TestCase
     public function testContents()
     {
         $file = new Remote('http://google.com');
-        $this->assertContains('html', $file->contents());
+        $this->assertStringContainsString('html', $file->contents());
     }
 
     public function testModifiedTime()

--- a/tests/TestCase/File/TargetTest.php
+++ b/tests/TestCase/File/TargetTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 
 class TargetTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->compiler = $this->getMockBuilder('MiniAsset\Output\CompilerInterface')->getMock();

--- a/tests/TestCase/Filter/FilterRegistryTest.php
+++ b/tests/TestCase/Filter/FilterRegistryTest.php
@@ -17,10 +17,11 @@ use MiniAsset\AssetTarget;
 use MiniAsset\Filter\AssetFilter;
 use MiniAsset\Filter\FilterRegistry;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class FilterRegistryTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->filters = [
@@ -57,11 +58,10 @@ class FilterRegistryTest extends TestCase
         $this->assertNull($this->registry->get('noop'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCollectionInvalidFilter()
     {
+        $this->expectException(RuntimeException::class);
+
         $target = new AssetTarget('test.js', [], ['noop', 'missing']);
         $this->registry->collection($target);
     }

--- a/tests/TestCase/Filter/HoganTest.php
+++ b/tests/TestCase/Filter/HoganTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class HoganTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_path = APP . '/hogan/';

--- a/tests/TestCase/Filter/ImportInlineTest.php
+++ b/tests/TestCase/Filter/ImportInlineTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class ImportInlineTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->filter = new ImportInline();

--- a/tests/TestCase/Filter/LessCssTest.php
+++ b/tests/TestCase/Filter/LessCssTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 class LessCssTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_cssDir = APP . 'css' . DS;

--- a/tests/TestCase/Filter/PipeInputFilterTest.php
+++ b/tests/TestCase/Filter/PipeInputFilterTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 class PipeInputFilterTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_cssDir = APP . 'css' . DS;

--- a/tests/TestCase/Filter/PipeOutputFilterTest.php
+++ b/tests/TestCase/Filter/PipeOutputFilterTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class PipeOutputFilterTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_cssDir = APP . 'css' . DS;

--- a/tests/TestCase/Filter/ScssFilterTest.php
+++ b/tests/TestCase/Filter/ScssFilterTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 class ScssFilterTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_cssDir = APP . 'css' . DS;

--- a/tests/TestCase/Filter/SimpleCssMinTest.php
+++ b/tests/TestCase/Filter/SimpleCssMinTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class SimpleCssMinTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_cssDir = APP . 'css' . DS;

--- a/tests/TestCase/Filter/SprocketsTest.php
+++ b/tests/TestCase/Filter/SprocketsTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 class SprocketsTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_testFiles = APP;

--- a/tests/TestCase/Filter/TimestampImageTest.php
+++ b/tests/TestCase/Filter/TimestampImageTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class TimestampImageTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_testPath = APP . 'css/';

--- a/tests/TestCase/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AssetMiddlewareTest.php
@@ -21,7 +21,7 @@ use Laminas\Diactoros\Response;
 
 class AssetMiddlewareTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $configFile = APP . 'config/integration.ini';
@@ -104,7 +104,7 @@ class AssetMiddlewareTest extends TestCase
         $this->assertNotSame($res, $response, 'Should be a new response');
         $this->assertSame(200, $res->getStatusCode(), 'Is 200 on success');
         $this->assertSame('application/css', $res->getHeaderLine('Content-Type'));
-        $this->assertContains('cached data', '' . $res->getBody(), 'Is cached data.');
+        $this->assertStringContainsString('cached data', '' . $res->getBody(), 'Is cached data.');
 
         unlink(sys_get_temp_dir() . '/all.css');
     }
@@ -123,7 +123,7 @@ class AssetMiddlewareTest extends TestCase
         $res = $this->middleware->__invoke($request, $response, $next);
         $this->assertNotSame($res, $response, 'Should be a new response');
         $this->assertSame(200, $res->getStatusCode(), 'Is 200 on success');
-        $this->assertContains('#nav {', '' . $res->getBody(), 'Looks like CSS.');
+        $this->assertStringContainsString('#nav {', '' . $res->getBody(), 'Looks like CSS.');
     }
 
     public function contentTypesProvider()

--- a/tests/TestCase/Output/AssetCacherTest.php
+++ b/tests/TestCase/Output/AssetCacherTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 class AssetCacherTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->files = [
@@ -48,7 +48,7 @@ class AssetCacherTest extends TestCase
         $this->themed->filterRegistry($registry);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
         $path = TMP . 'Modern-template.js';

--- a/tests/TestCase/Output/AssetWriterTest.php
+++ b/tests/TestCase/Output/AssetWriterTest.php
@@ -23,7 +23,7 @@ class AssetWriterTest extends TestCase
 {
     protected $files = [];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->files = [

--- a/tests/TestCase/Output/CachedCompilerTest.php
+++ b/tests/TestCase/Output/CachedCompilerTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 class CachedCompilerTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_testFiles = APP;

--- a/tests/TestCase/Output/CompilerTest.php
+++ b/tests/TestCase/Output/CompilerTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 class CompilerTest extends TestCase
 {
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_testFiles = APP;


### PR DESCRIPTION
# Changed log

- Since this PHP package requires `php-7.2` version at least, it can upgrade the `PHPUnit` version to `8.0+`.
- Adding the `.phpunit.result.cache` file that is generated by `PHPUnit 8.x` version.
- Adding the `php-7.3` version test during Travis CI build.
- Remove the `--dev` option for `` command because the following deprecated message:

```
You are using the deprecated option "--dev". It has no effect and will break in Composer 3.
```
- Since upgrading to the `PHPUnit ^8` version, it should use the `expectException` and `expectExceptionMessage` methods to replace annotation approaches.
- Using the `assertStringContainsString` assertion to replace `assertContains` for assert contained string.
- According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should use the `protected function setUp(): void` and `protected function tearDown(): void` methods.