### PR TITLE
Fix PHP8 deprecations and update deprecated usage of PHPUnit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0']
+        php-version: ['7.2', '7.4', '8.0', '8.1']
         prefer-lowest: ['']
         include:
           - php-version: '7.2'
@@ -49,7 +49,7 @@ jobs:
 
     - name: Composer install
       run: |
-        if [[ ${{ matrix.php-version }} == '8.0' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.0' || ${{ matrix.php-version }} == '8.1' ]]; then
           composer install --ignore-platform-reqs
         elif ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
           composer update --prefer-lowest --prefer-stable
@@ -59,14 +59,14 @@ jobs:
 
     - name: Run PHPUnit
       run: |
-        if [[ ${{ matrix.php-version }} == '7.4' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.1' ]]; then
           vendor/bin/phpunit --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
         fi
 
     - name: Code Coverage Report
-      if: success() && matrix.php-version == '7.4'
+      if: success() && matrix.php-version == '8.1'
       uses: codecov/codecov-action@v1
 
   cs-stan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       run: vendor/bin/phpcs -p src/ tests/
 
     - name: Run psalm
-      run: psalm --output-format=github
+      run: vendor/bin/psalm.phar --output-format=github
 
     - name: Run phpstan
-      run: phpstan analyse
+      run: vendor/bin/phpstan.phar analyse --error-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,12 @@ jobs:
         php-version: '7.4'
         extensions: mbstring, intl
         coverage: none
-        tools: psalm:~4.1.0, phpstan:^0.12
 
     - name: Composer Install
       run: composer install
+
+    - name: Install tools
+      run: composer stan-setup
 
     - name: Run phpcs
       run: vendor/bin/phpcs -p src/ tests/

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "source": "https://github.com/markstory/mini-asset"
   },
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.2,<8.2",
     "league/climate": "~3.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,9 @@
     "cs-check": "phpcs -p src/ tests/TestCase/",
     "cs-fix": "phpcbf src/ tests/TestCase/",
     "test": "phpunit --stderr",
-    "stan": "phpstan analyse src/ && psalm --show-info=false",
     "stan-test": "phpstan analyse tests/",
-    "psalm": "psalm",
-    "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 vimeo/psalm:^4.1.0 && mv composer.backup composer.json"
+    "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.5 psalm/phar:~4.22.0 && mv composer.backup composer.json",
+    "stan": "phpstan analyse src/ && psalm --show-info=false",
+    "psalm": "psalm"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "test": "phpunit --stderr",
     "stan-test": "phpstan analyse tests/",
     "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.5 psalm/phar:~4.22.0 && mv composer.backup composer.json",
-    "stan": "phpstan analyse src/ && psalm --show-info=false",
-    "psalm": "psalm"
+    "stan": "phpstan analyse src/ && psalm.phar --show-info=false",
+    "psalm": "psalm.phar --show-info=false"
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,10 +6,6 @@ parameters:
         - src/
     ignoreErrors:
         -
-            message: "#^Function jsmin not found.#"
-            count: 1
-            path: src/Filter/JsMinFilter.php
-        -
             message: "#^Call to method minify\\(\\) on an unknown class.*#"
             count: 2
             path: src/Filter/MinifyFilter.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
     errorLevel="7"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/AssetCollection.php
+++ b/src/AssetCollection.php
@@ -139,16 +139,19 @@ class AssetCollection implements Countable, Iterator
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->index = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->index++;
@@ -159,6 +162,7 @@ class AssetCollection implements Countable, Iterator
         return $this->index;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->items[$this->index]);

--- a/src/Filter/FilterCollection.php
+++ b/src/Filter/FilterCollection.php
@@ -73,6 +73,7 @@ class FilterCollection implements Countable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->filters);

--- a/src/Filter/PipeInputFilter.php
+++ b/src/Filter/PipeInputFilter.php
@@ -55,12 +55,12 @@ class PipeInputFilter extends AssetFilter
         return $this->_settings['dependencies'];
     }
 
-    public function getDependencies(AssetTarget $file)
+    public function getDependencies(AssetTarget $target)
     {
         if ($this->_settings['dependencies']) {
             $this->optionalDependencyPrefix = $this->_settings['optional_dependency_prefix'];
 
-            return $this->getCssDependencies($file);
+            return $this->getCssDependencies($target);
         }
 
         return [];

--- a/src/Output/AssetWriter.php
+++ b/src/Output/AssetWriter.php
@@ -188,8 +188,8 @@ class AssetWriter
      */
     protected function _readTimestamp()
     {
-        $data = array();
-        if (empty($data) && file_exists($this->path . static::BUILD_TIME_FILE)) {
+        $data = [];
+        if (file_exists($this->path . static::BUILD_TIME_FILE)) {
             $data = file_get_contents($this->path . static::BUILD_TIME_FILE);
             if ($data) {
                 $data = unserialize($data);

--- a/tests/TestCase/Cli/ClearTaskTest.php
+++ b/tests/TestCase/Cli/ClearTaskTest.php
@@ -96,7 +96,7 @@ class ClearTaskTest extends TestCase
         $this->task->main(['clear', '--config', APP . 'config/integration.ini']);
 
         foreach ($files as $file) {
-            $this->assertFileNotExists($file, "$file was not cleared");
+            $this->assertFalse(file_exists($file), "$file was not cleared");
         }
     }
 

--- a/tests/TestCase/Filter/ClosureJsTest.php
+++ b/tests/TestCase/Filter/ClosureJsTest.php
@@ -22,21 +22,25 @@ class ClosureJsTest extends TestCase
     public function testCommand()
     {
         $filter = $this->getMockBuilder('MiniAsset\Filter\ClosureJs')
-            ->setMethods(['_findExecutable', '_runCmd'])
+            ->onlyMethods(['_findExecutable', '_runCmd'])
             ->getMock();
 
-        $filter->expects($this->at(0))
+        $filter->expects($this->any())
             ->method('_findExecutable')
             ->will($this->returnValue('closure/compiler.jar'));
-        $filter->expects($this->at(1))
+        $filter->expects($this->once())
             ->method('_runCmd')
             ->with($this->matchesRegularExpression('/java -jar "closure\/compiler\.jar" --js=(.*)\/CLOSURE(.*) --warning_level="QUIET"/'));
         $filter->output('file.js', 'var a = 1;');
 
-        $filter->expects($this->at(0))
+
+        $filter = $this->getMockBuilder('MiniAsset\Filter\ClosureJs')
+            ->onlyMethods(['_findExecutable', '_runCmd'])
+            ->getMock();
+        $filter->expects($this->any())
             ->method('_findExecutable')
             ->will($this->returnValue('closure/compiler.jar'));
-        $filter->expects($this->at(1))
+        $filter->expects($this->once())
             ->method('_runCmd')
             ->with($this->matchesRegularExpression('/java -jar "closure\/compiler\.jar" --js=(.*)\/CLOSURE(.*) --warning_level="QUIET" --language_in="ECMASCRIPT5"/'));
         $filter->settings(array('language_in' => 'ECMASCRIPT5'));


### PR DESCRIPTION
* Add PHP8.1 to build matrix.
* Add upper PHP version boundary so the supported PHP versions are
  easier to find. Long term this will help keep compatibility ranges
  reasonable for me to maintain.

Refs markstory/asset_compress#363