### PR TITLE
Upgrade to PHP 8.1 types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0', '8.1']
+        php-version: ['8.1']
         prefer-lowest: ['']
         include:
-          - php-version: '7.2'
+          - php-version: '8.1'
             prefer-lowest: 'prefer-lowest'
 
     steps:
@@ -81,7 +81,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "league/climate": "~3.0"
   },
   "require-dev": {
+    "cakephp/cakephp-codesniffer": "5.x-dev",
     "squizlabs/php_codesniffer": "*",
     "laminas/laminas-diactoros": "~2.0",
     "phpunit/phpunit": "^8.5 | ^9.3"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "source": "https://github.com/markstory/mini-asset"
   },
   "require": {
-    "php": ">=7.2,<8.2",
+    "php": ">=8.1,<9",
     "league/climate": "~3.0"
   },
   "require-dev": {
@@ -59,5 +59,10 @@
     "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.5 psalm/phar:~4.22.0 && mv composer.backup composer.json",
     "stan": "phpstan analyse src/ && psalm.phar --show-info=false",
     "psalm": "psalm.phar --show-info=false"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <ruleset name="MiniAsset">
-    <rule ref="PSR2"/>
+    <rule ref="CakePHP"/>
 
     <exclude-pattern>tests/bootstrap.php</exclude-pattern>
     <exclude-pattern>tests/test_files/js/*</exclude-pattern>
     <exclude-pattern>tests/test_files/css/*</exclude-pattern>
+    <rule ref="CakePHP.Commenting.FunctionComment.Missing">
+        <severity>0</severity>
+    </rule>
     <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
         <severity>0</severity>
     </rule>

--- a/src/AssetCollection.php
+++ b/src/AssetCollection.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,12 +15,9 @@
  */
 namespace MiniAsset;
 
-use MiniAsset\AssetConfig;
-use MiniAsset\AssetTarget;
-use MiniAsset\Factory;
 use Countable;
 use Iterator;
-use InvalidArgumentException;
+use ReturnTypeWillChange;
 
 /**
  * A collection of AssetTargets.
@@ -34,35 +33,35 @@ class AssetCollection implements Countable, Iterator
      *
      * @var array
      */
-    protected $indexed = [];
+    protected array $indexed = [];
 
     /**
      * The assets indexed numerically.
      *
      * @var array
      */
-    protected $items = [];
+    protected array $items = [];
 
     /**
      * The current position.
      *
      * @var int
      */
-    protected $index = 0;
+    protected int $index = 0;
 
     /**
      * A factory instance that can be used to lazily build targets.
      *
      * @var \MiniAsset\Factory
      */
-    protected $factory;
+    protected Factory $factory;
 
     /**
      * Constructor. You can provide an array or any traversable object
      *
-     * @param  array $targets Items.
-     * @param  \MiniAsset\Factory $factory Factory for other objects.
-     * @throws InvalidArgumentException If passed incorrect type for items.
+     * @param array $targets Items.
+     * @param \MiniAsset\Factory $factory Factory for other objects.
+     * @throws \InvalidArgumentException If passed incorrect type for items.
      */
     public function __construct(array $targets, Factory $factory)
     {
@@ -76,10 +75,10 @@ class AssetCollection implements Countable, Iterator
     /**
      * Append an asset to the collection.
      *
-     * @param  AssetTarget $target The target to append
+     * @param \MiniAsset\AssetTarget $target The target to append
      * @return void
      */
-    public function append(AssetTarget $target)
+    public function append(AssetTarget $target): void
     {
         $name = $target->name();
         $this->indexed[$name] = $target;
@@ -89,10 +88,10 @@ class AssetCollection implements Countable, Iterator
     /**
      * Get an asset from the collection
      *
-     * @param  string $name The name of the asset you want.
-     * @return null|AssetTarget Either null or the asset target.
+     * @param string $name The name of the asset you want.
+     * @return \MiniAsset\AssetTarget|null Either null or the asset target.
      */
-    public function get($name)
+    public function get(string $name): ?AssetTarget
     {
         if (!isset($this->indexed[$name])) {
             return null;
@@ -100,16 +99,17 @@ class AssetCollection implements Countable, Iterator
         if (empty($this->indexed[$name])) {
             $this->indexed[$name] = $this->factory->target($name);
         }
+
         return $this->indexed[$name];
     }
 
     /**
      * Check whether or not the collection contains the named asset.
      *
-     * @param  string $name The name of the asset you want.
+     * @param string $name The name of the asset you want.
      * @return bool
      */
-    public function contains($name)
+    public function contains(string $name): bool
     {
         return isset($this->indexed[$name]);
     }
@@ -117,10 +117,10 @@ class AssetCollection implements Countable, Iterator
     /**
      * Remove an asset from the collection
      *
-     * @param  string $name The name of the asset you want to remove
+     * @param string $name The name of the asset you want to remove
      * @return void
      */
-    public function remove($name)
+    public function remove(string $name): void
     {
         if (!isset($this->indexed[$name])) {
             return;
@@ -154,7 +154,7 @@ class AssetCollection implements Countable, Iterator
         $this->index++;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->index;
@@ -165,10 +165,11 @@ class AssetCollection implements Countable, Iterator
         return isset($this->items[$this->index]);
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function current()
     {
         $current = $this->items[$this->index];
+
         return $this->get($current);
     }
 }

--- a/src/AssetCollection.php
+++ b/src/AssetCollection.php
@@ -17,7 +17,6 @@ namespace MiniAsset;
 
 use Countable;
 use Iterator;
-use ReturnTypeWillChange;
 
 /**
  * A collection of AssetTargets.
@@ -134,11 +133,6 @@ class AssetCollection implements Countable, Iterator
         }
     }
 
-    /**
-     * Get the length of the collection.
-     *
-     * @return int
-     */
     public function count(): int
     {
         return count($this->items);
@@ -154,8 +148,7 @@ class AssetCollection implements Countable, Iterator
         $this->index++;
     }
 
-    #[ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         return $this->index;
     }
@@ -165,8 +158,7 @@ class AssetCollection implements Countable, Iterator
         return isset($this->items[$this->index]);
     }
 
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): AssetTarget
     {
         $current = $this->items[$this->index];
 

--- a/src/AssetCompiler.php
+++ b/src/AssetCompiler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)

--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -438,7 +438,7 @@ class AssetConfig
     /**
      * Get/Set filter Settings.
      *
-     * @param string|array $filter The filter name, or a list of filter configuration to set.
+     * @param array|string $filter The filter name, or a list of filter configuration to set.
      * @param array $settings The settings to set, leave null to get
      * @return mixed.
      */

--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -123,7 +123,7 @@ class AssetConfig
                 if (is_array($value) || strpos($value, DIRECTORY_SEPARATOR) === false) {
                     continue;
                 }
-                if ($value !== DIRECTORY_SEPARATOR && !@file_exists($value)) {
+                if ($value !== DIRECTORY_SEPARATOR && !file_exists($value)) {
                     continue;
                 }
                 $this->constantMap[$key] = rtrim($value, DIRECTORY_SEPARATOR);
@@ -316,11 +316,11 @@ class AssetConfig
      * with this. Use the appropriate methods for those settings.
      *
      * @param string $path  The path to set.
-     * @param string $value The value to set.
+     * @param mixed $value The value to set.
      * @return void
      * @throws \RuntimeException
      */
-    public function set(string $path, string $value): void
+    public function set(string $path, mixed $value): void
     {
         $parts = explode('.', $path);
         switch (count($parts)) {
@@ -352,12 +352,14 @@ class AssetConfig
                 if (isset($this->_data[$parts[0]][$parts[1]])) {
                     return $this->_data[$parts[0]][$parts[1]];
                 }
-                break;
+
+                return null;
             case 1:
                 if (isset($this->_data[$parts[0]])) {
                     return $this->_data[$parts[0]];
                 }
-                break;
+
+                return null;
             case 0:
                 throw new RuntimeException('Path was empty.');
             default:
@@ -382,6 +384,8 @@ class AssetConfig
             return [];
         }
         $this->_data[$ext][self::FILTERS] = $filters;
+
+        return null;
     }
 
     /**
@@ -434,11 +438,11 @@ class AssetConfig
     /**
      * Get/Set filter Settings.
      *
-     * @param string $filter   The filter name
-     * @param array  $settings The settings to set, leave null to get
+     * @param string|array $filter The filter name, or a list of filter configuration to set.
+     * @param array $settings The settings to set, leave null to get
      * @return mixed.
      */
-    public function filterConfig(string $filter, ?array $settings = null): mixed
+    public function filterConfig(string|array $filter, ?array $settings = null): mixed
     {
         if ($settings === null) {
             if (is_string($filter)) {
@@ -456,6 +460,8 @@ class AssetConfig
 
         // array_map_recursive
         $this->_filters[$filter] = filter_var($settings, FILTER_CALLBACK, ['options' => [$this, '_replacePathConstants']]);
+
+        return null;
     }
 
     /**
@@ -535,6 +541,8 @@ class AssetConfig
         } else {
             $this->_targets[$target]['paths'] = $paths;
         }
+
+        return null;
     }
 
     /**
@@ -542,8 +550,9 @@ class AssetConfig
      *
      * @param string $ext  Extension to get paths for.
      * @param string $path The path to cache files using $ext to.
+     * @return ?string Path to cache directory for the extension
      */
-    public function cachePath(string $ext, ?string $path = null)
+    public function cachePath(string $ext, ?string $path = null): ?string
     {
         if ($path === null) {
             if (isset($this->_data[$ext]['cachePath'])) {
@@ -554,6 +563,8 @@ class AssetConfig
         }
         $path = $this->_replacePathConstants($path);
         $this->_data[$ext]['cachePath'] = rtrim($path, '/') . '/';
+
+        return null;
     }
 
     /**
@@ -633,6 +644,8 @@ class AssetConfig
             return $this->_data['theme'] ?? '';
         }
         $this->_data['theme'] = $theme;
+
+        return null;
     }
 
     /**

--- a/src/AssetProcess.php
+++ b/src/AssetProcess.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -19,84 +21,85 @@ namespace MiniAsset;
  */
 class AssetProcess
 {
-
     /**
      * Environment variables for the sub process.
      *
      * @var array
      */
-    protected $_env = null;
+    protected array $_env = null;
 
     /**
      * The command that is being run.
      *
      * @var string
      */
-    protected $_command = '';
+    protected string $_command = '';
 
     /**
      * The stderr output.
      *
      * @var string
      */
-    protected $_error;
+    protected string $_error;
 
     /**
      * The stdout output.
      *
      * @var string
      */
-    protected $_output;
+    protected string $_output;
 
     /**
      * Get/set the environment for the command.
      *
      * @param array $env Environment variables.
-     *
-     * @return array|static The environment variables that are set, or this.
+     * @return static|array The environment variables that are set, or this.
      */
-    public function environment($env = null)
+    public function environment(?array $env = null): array|static
     {
         if ($env !== null) {
             // Windows nodejs needs these environment variables.
-            $winenv = $this->_getenv(array('SystemDrive', 'SystemRoot'));
+            $winenv = $this->_getenv(['SystemDrive', 'SystemRoot']);
             $this->_env = array_merge($winenv, $env);
+
             return $this;
         }
+
         return $this->_env;
     }
 
     /**
      * Gets selected variables from the global environment.
      *
-     * @param  array $vars An array of variable names to load
+     * @param array $vars An array of variable names to load
      * @return array The values of selected environment variables if they
      *    are set.
      */
-    protected function _getenv(array $vars)
+    protected function _getenv(array $vars): array
     {
-        $result = array();
+        $result = [];
         foreach ($vars as $var) {
             if (getenv($var)) {
                 $result[$var] = getenv($var);
             }
         }
+
         return $result;
     }
 
     /**
      * Run the command and capture the output as the return.
      *
-     * @param  string $input STDIN for the command.
+     * @param string $input STDIN for the command.
      * @return string Output from the command.
      */
-    public function run($input = null)
+    public function run(?string $input = null): string
     {
-        $descriptorSpec = array(
-            0 => array('pipe', 'r'),
-            1 => array('pipe', 'w'),
-            2 => array('pipe', 'w')
-        );
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
         $process = proc_open(
             $this->_command,
             $descriptorSpec,
@@ -115,6 +118,7 @@ class AssetProcess
             fclose($pipes[2]);
             proc_close($process);
         }
+
         return $this->_output;
     }
 
@@ -123,7 +127,7 @@ class AssetProcess
      *
      * @return string Content from the command.
      */
-    public function error()
+    public function error(): string
     {
         return trim($this->_error);
     }
@@ -133,7 +137,7 @@ class AssetProcess
      *
      * @return string Content from the command.
      */
-    public function output()
+    public function output(): string
     {
         return $this->_output;
     }
@@ -141,10 +145,10 @@ class AssetProcess
     /**
      * Set the command that will be run.
      *
-     * @param  string $command Command name to run.
+     * @param string $command Command name to run.
      * @return $this
      */
-    public function command($command)
+    public function command(string $command)
     {
         // Wrap Windows exe in quotes if needed. "C:\Program Files\nodejs\node.exe"
         // Checks for path name with one or more spaces followed by `.exe`
@@ -152,6 +156,7 @@ class AssetProcess
         // Unix commands wont have .exe so they remain unchanged.
         $command = preg_replace('/^\s*([^"\s]+\s.+\.exe)(\s|$)/', '"$1"$2', $command);
         $this->_command = $command;
+
         return $this;
     }
 }

--- a/src/AssetProcess.php
+++ b/src/AssetProcess.php
@@ -26,7 +26,7 @@ class AssetProcess
      *
      * @var array
      */
-    protected array $_env = null;
+    protected ?array $_env = null;
 
     /**
      * The command that is being run.
@@ -40,7 +40,7 @@ class AssetProcess
      *
      * @var string
      */
-    protected string $_error;
+    protected ?string $_error;
 
     /**
      * The stdout output.

--- a/src/AssetScanner.php
+++ b/src/AssetScanner.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset;
 
-use RuntimeException;
-
 /**
  * Used for dynamic build files where a set of searchPaths
  * are declared in the config file. This class allows you search through
@@ -22,13 +22,12 @@ use RuntimeException;
  */
 class AssetScanner
 {
-
     /**
      * Paths this scanner should scan.
      *
      * @var array
      */
-    protected $_paths = [];
+    protected array $_paths = [];
 
     /**
      * Constructor.
@@ -48,7 +47,7 @@ class AssetScanner
      *
      * @return void
      */
-    protected function _normalizePaths()
+    protected function _normalizePaths(): void
     {
         foreach ($this->_paths as &$path) {
             $ds = DIRECTORY_SEPARATOR;
@@ -60,13 +59,13 @@ class AssetScanner
     /**
      * Normalize a file path to the specified Directory Separator ($ds)
      *
-     * @param  string $name Path to normalize
-     * @param  string $ds   Directory Separator to be used
+     * @param string $name Path to normalize
+     * @param string $ds   Directory Separator to be used
      * @return string Normalized path
      */
-    protected function _normalizePath($name, $ds)
+    protected function _normalizePath(string $name, string $ds): string
     {
-        return str_replace(array('/', '\\'), $ds, $name);
+        return str_replace(['/', '\\'], $ds, $name);
     }
 
     /**
@@ -74,9 +73,9 @@ class AssetScanner
      *
      * @return void
      */
-    protected function _expandPaths()
+    protected function _expandPaths(): void
     {
-        $expanded = array();
+        $expanded = [];
         foreach ($this->_paths as $path) {
             if (preg_match('/[*.\[\]]/', $path)) {
                 $tree = $this->_generateTree($path);
@@ -91,26 +90,27 @@ class AssetScanner
     /**
      * Discover all the sub directories for a given path.
      *
-     * @param  string $path The path to search
+     * @param string $path The path to search
      * @return array Array of subdirectories.
      */
-    protected function _generateTree($path)
+    protected function _generateTree(string $path): array
     {
         $paths = glob($path, GLOB_ONLYDIR);
         if (!$paths) {
-            $paths = array();
+            $paths = [];
         }
         array_unshift($paths, dirname($path));
+
         return $paths;
     }
 
     /**
      * Find a file in the connected paths, and check for its existance.
      *
-     * @param  string $file The file you want to find.
-     * @return false|string Either false on a miss, or the full path of the file.
+     * @param string $file The file you want to find.
+     * @return string|false Either false on a miss, or the full path of the file.
      */
-    public function find($file)
+    public function find(string $file): false|string
     {
         $found = false;
         $expanded = $this->_expandPrefix($file);
@@ -126,6 +126,7 @@ class AssetScanner
                 break;
             }
         }
+
         return $found;
     }
 
@@ -133,10 +134,10 @@ class AssetScanner
      * Path resolution hook. Used by framework integrations to add in
      * framework module paths.
      *
-     * @param  string $path Path to resolve
+     * @param string $path Path to resolve
      * @return string resolved path
      */
-    protected function _expandPrefix($path)
+    protected function _expandPrefix(string $path): string
     {
         return $path;
     }
@@ -146,7 +147,7 @@ class AssetScanner
      *
      * @return array an array of paths.
      */
-    public function paths()
+    public function paths(): array
     {
         return $this->_paths;
     }

--- a/src/AssetTarget.php
+++ b/src/AssetTarget.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -24,38 +26,38 @@ class AssetTarget
     /**
      * @var string
      */
-    protected $path;
+    protected string $path;
 
     /**
-     * @var \MiniAsset\File\FileInterface[]
+     * @var array<\MiniAsset\File\FileInterface>
      */
-    protected $files = [];
-
-    /**
-     * @var array
-     */
-    protected $filters = [];
+    protected array $files = [];
 
     /**
      * @var array
      */
-    protected $paths = [];
+    protected array $filters = [];
+
+    /**
+     * @var array
+     */
+    protected array $paths = [];
 
     /**
      * @var bool
      */
-    protected $themed;
+    protected bool $themed;
 
     /**
      * @param string                          $path    The output path or the asset target.
-     * @param \MiniAsset\File\FileInterface[] $files   An array of MiniAsset\File\FileInterface
+     * @param array<\MiniAsset\File\FileInterface> $files An array of MiniAsset\File\FileInterface
      * @param array                           $filters An array of filter names for this target.
      * @param array                           $paths   A list of search paths for this asset. These paths
      *                                                 are used by filters that allow additional
      *                                                 resources to be included e.g. Sprockets
      * @param bool                            $themed  Whether or not this file should be themed.
      */
-    public function __construct($path, $files = [], $filters = [], $paths = [], $themed = false)
+    public function __construct(string $path, array $files = [], array $filters = [], array $paths = [], bool $themed = false)
     {
         $this->path = $path;
         $this->files = $files;
@@ -67,7 +69,7 @@ class AssetTarget
     /**
      * @return bool
      */
-    public function isThemed()
+    public function isThemed(): bool
     {
         return $this->themed;
     }
@@ -75,15 +77,15 @@ class AssetTarget
     /**
      * @return array
      */
-    public function paths()
+    public function paths(): array
     {
         return $this->paths;
     }
 
     /**
-     * @return \MiniAsset\File\FileInterface[]
+     * @return array<\MiniAsset\File\FileInterface>
      */
-    public function files()
+    public function files(): array
     {
         return $this->files;
     }
@@ -91,7 +93,7 @@ class AssetTarget
     /**
      * @return string
      */
-    public function path()
+    public function path(): string
     {
         return $this->path;
     }
@@ -99,7 +101,7 @@ class AssetTarget
     /**
      * @return string
      */
-    public function outputDir()
+    public function outputDir(): string
     {
         return dirname($this->path);
     }
@@ -107,7 +109,7 @@ class AssetTarget
     /**
      * @return string
      */
-    public function name()
+    public function name(): string
     {
         return basename($this->path);
     }
@@ -115,16 +117,17 @@ class AssetTarget
     /**
      * @return string
      */
-    public function ext()
+    public function ext(): string
     {
         $parts = explode('.', $this->name());
+
         return array_pop($parts);
     }
 
     /**
      * @return array
      */
-    public function filterNames()
+    public function filterNames(): array
     {
         return $this->filters;
     }
@@ -132,11 +135,12 @@ class AssetTarget
     /**
      * @return int
      */
-    public function modifiedTime()
+    public function modifiedTime(): int
     {
         if (file_exists($this->path)) {
             return filemtime($this->path);
         }
+
         return 0;
     }
 }

--- a/src/Cli/BaseTask.php
+++ b/src/Cli/BaseTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,6 +15,8 @@
  */
 namespace MiniAsset\Cli;
 
+use Exception;
+use League\CLImate\CLImate;
 use MiniAsset\AssetConfig;
 
 abstract class BaseTask
@@ -26,7 +30,7 @@ abstract class BaseTask
      * @param \League\CLImate\CLImate $cli    The CLImate instance.
      * @param array                   $config Configuration data.
      */
-    public function __construct($cli, $config = null)
+    public function __construct(CLImate $cli, ?array $config = null)
     {
         $this->cli = $cli;
         $this->config = $config;
@@ -37,35 +41,39 @@ abstract class BaseTask
      *
      * @return \MiniAsset\AssetConfig
      */
-    public function config()
+    public function config(): AssetConfig
     {
         if (!$this->config) {
             $config = new AssetConfig();
             $config->load($this->cli->arguments->get('config'));
             $this->config = $config;
         }
+
         return $this->config;
     }
 
     /**
      * Execute the task given a set of CLI arguments.
      *
-     * @param  array $argv The arguments to use.
+     * @param array $argv The arguments to use.
      * @return int
      */
-    public function main($argv)
+    public function main(array $argv): int
     {
         $this->addArguments();
         try {
             $this->cli->arguments->parse($argv);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->cli->usage();
+
             return 0;
         }
         if ($this->cli->arguments->get('help')) {
             $this->cli->usage();
+
             return 0;
         }
+
         return $this->execute();
     }
 
@@ -74,15 +82,15 @@ abstract class BaseTask
      *
      * @param string $text  The text to output.
      * @param string $short The short alternative.
-     *
      * @return void
      */
-    public function verbose($text, $short = '')
+    public function verbose(string $text, string $short = ''): void
     {
         if (!$this->cli->arguments->defined('verbose')) {
             if (strlen($short)) {
                 $this->cli->inline($short);
             }
+
             return;
         }
         $this->cli->out($text);
@@ -94,7 +102,7 @@ abstract class BaseTask
      *
      * @return void
      */
-    protected function bootstrapApp()
+    protected function bootstrapApp(): void
     {
         $files = explode(',', $this->cli->arguments->get('bootstrap'));
         foreach ($files as $file) {
@@ -107,12 +115,12 @@ abstract class BaseTask
      *
      * @return void
      */
-    abstract protected function addArguments();
+    abstract protected function addArguments(): void;
 
     /**
      * Used by subclasses to execute work.
      *
      * @return int
      */
-    abstract protected function execute();
+    abstract protected function execute(): int;
 }

--- a/src/Cli/BaseTask.php
+++ b/src/Cli/BaseTask.php
@@ -21,16 +21,16 @@ use MiniAsset\AssetConfig;
 
 abstract class BaseTask
 {
-    protected $cli;
-    protected $config;
+    protected CLImate $cli;
+    protected ?AssetConfig $config;
 
     /**
      * Constructor
      *
-     * @param \League\CLImate\CLImate $cli    The CLImate instance.
-     * @param array                   $config Configuration data.
+     * @param \League\CLImate\CLImate $cli The CLImate instance.
+     * @param \MiniAsset\AssetConfig|null $config Configuration data.
      */
-    public function __construct(CLImate $cli, ?array $config = null)
+    public function __construct(CLImate $cli, ?AssetConfig $config = null)
     {
         $this->cli = $cli;
         $this->config = $config;

--- a/src/Cli/BuildTask.php
+++ b/src/Cli/BuildTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,22 +15,21 @@
  */
 namespace MiniAsset\Cli;
 
-use MiniAsset\Cli\BaseTask;
+use Exception;
+use MiniAsset\AssetTarget;
 use MiniAsset\Factory;
-use \Exception;
 
 /**
  * Provides the `mini_asset build` command.
  */
 class BuildTask extends BaseTask
 {
-
     /**
      * Define the CLI options.
      *
      * @return void
      */
-    protected function addArguments()
+    protected function addArguments(): void
     {
         $this->cli->arguments->add(
             [
@@ -55,14 +56,14 @@ class BuildTask extends BaseTask
                 'longPrefix' => 'bootstrap',
                 'description' => 'Comma separated list of files to include bootstrap your ' .
                     'application\s environment.',
-                'defaultValue' => ''
+                'defaultValue' => '',
             ],
             'config' => [
                 'prefix' => 'c',
                 'longPrefix' => 'config',
                 'description' => 'The config file to use.',
                 'required' => true,
-            ]
+            ],
             ]
         );
     }
@@ -72,7 +73,7 @@ class BuildTask extends BaseTask
      *
      * @return int
      */
-    protected function execute()
+    protected function execute(): int
     {
         if ($this->cli->arguments->defined('bootstrap')) {
             $this->bootstrapApp();
@@ -83,17 +84,18 @@ class BuildTask extends BaseTask
             $this->_buildTarget($factory, $target);
         }
         $this->cli->out('<green>Complete</green>');
+
         return 0;
     }
 
     /**
      * Generate and save the cached file for a build target.
      *
-     * @param  \MiniAsset\Factory     $factory The factory class.
-     * @param  \MiniAsset\AssetTarget $build   The build target.
+     * @param \MiniAsset\Factory     $factory The factory class.
+     * @param \MiniAsset\AssetTarget $build   The build target.
      * @return void
      */
-    protected function _buildTarget($factory, $build)
+    protected function _buildTarget(Factory $factory, AssetTarget $build): void
     {
         $writer = $factory->writer();
         $compiler = $factory->cachedCompiler();
@@ -101,6 +103,7 @@ class BuildTask extends BaseTask
         $name = $writer->buildFileName($build);
         if ($writer->isFresh($build) && !$this->cli->arguments->defined('force')) {
             $this->verbose('<light_blue>Skip building</light_blue> ' . $name . ' existing file is still fresh.', 'S');
+
             return;
         }
 

--- a/src/Cli/ClearTask.php
+++ b/src/Cli/ClearTask.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -14,13 +16,11 @@
 namespace MiniAsset\Cli;
 
 use DirectoryIterator;
-use MiniAsset\Cli\BaseTask;
 use MiniAsset\Factory;
 
 class ClearTask extends BaseTask
 {
-
-    protected function addArguments()
+    protected function addArguments(): void
     {
         $this->cli->arguments->add(
             [
@@ -48,7 +48,7 @@ class ClearTask extends BaseTask
                 'longPrefix' => 'config',
                 'description' => 'The config file to use.',
                 'required' => true,
-            ]
+            ],
             ]
         );
     }
@@ -69,6 +69,7 @@ class ClearTask extends BaseTask
         $assets = $factory->assetCollection();
         if (count($assets) === 0) {
             $this->cli->err('<red>No build targets defined</red>.');
+
             return 1;
         }
 
@@ -83,21 +84,22 @@ class ClearTask extends BaseTask
     /**
      * Clear a path of build targets.
      *
-     * @param  string $path    The root path to clear.
-     * @param  array  $targets The build targets to clear.
+     * @param string $path    The root path to clear.
+     * @param array  $targets The build targets to clear.
      * @return void
      */
-    protected function _clearPath($path, $targets)
+    protected function _clearPath(string $path, array $targets): void
     {
         if (!file_exists($path)) {
             $this->verbose("Not clearing '$path' it does not exist.");
+
             return;
         }
 
         $dir = new DirectoryIterator($path);
         foreach ($dir as $file) {
             $name = $base = $file->getFilename();
-            if (in_array($name, array('.', '..'))) {
+            if (in_array($name, ['.', '..'])) {
                 continue;
             }
             // timestampped files.

--- a/src/Cli/ClearTask.php
+++ b/src/Cli/ClearTask.php
@@ -53,7 +53,7 @@ class ClearTask extends BaseTask
         );
     }
 
-    protected function execute()
+    protected function execute(): int
     {
         if ($this->cli->arguments->defined('bootstrap')) {
             $this->bootstrapApp();

--- a/src/Cli/MiniAsset.php
+++ b/src/Cli/MiniAsset.php
@@ -22,9 +22,9 @@ use League\CLImate\CLImate;
  */
 class MiniAsset
 {
-    protected $cli;
-    protected $build;
-    protected $clear;
+    protected CLImate $cli;
+    protected BaseTask $build;
+    protected BaseTask $clear;
 
     public function __construct()
     {
@@ -33,7 +33,7 @@ class MiniAsset
         $this->clear = new ClearTask($this->cli);
     }
 
-    public function main($argv)
+    public function main(array $argv): int
     {
         if (empty($argv)) {
             $this->help();

--- a/src/Cli/MiniAsset.php
+++ b/src/Cli/MiniAsset.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -14,8 +16,6 @@
 namespace MiniAsset\Cli;
 
 use League\CLImate\CLImate;
-use MiniAsset\Cli\ClearTask;
-use MiniAsset\Cli\BuildTask;
 
 /**
  * CLI entry point for MiniAsset.
@@ -37,6 +37,7 @@ class MiniAsset
     {
         if (empty($argv)) {
             $this->help();
+
             return 1;
         }
         switch ($argv[0]) {
@@ -46,6 +47,7 @@ class MiniAsset
                 return $this->clear->main($argv);
             default:
                 $this->help();
+
                 return 1;
         }
     }

--- a/src/File/Callback.php
+++ b/src/File/Callback.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -30,7 +32,7 @@ class Callback
     /**
      * @var \MiniAsset\AssetScanner
      */
-    protected $scanner;
+    protected AssetScanner $scanner;
 
     /**
      * Constructor
@@ -39,11 +41,11 @@ class Callback
      * @param string                  $method  The method to invoke.
      * @param \MiniAsset\AssetScanner $scanner The asset scanner.
      */
-    public function __construct($class, $method, AssetScanner $scanner)
+    public function __construct(string $class, string $method, AssetScanner $scanner)
     {
         $callable = $class . '::' . $method;
         if (!is_callable($callable)) {
-            throw new \RuntimeException("Callback {$callable}() is not callable");
+            throw new RuntimeException("Callback {$callable}() is not callable");
         }
         $this->callable = $callable;
         $this->scanner = $scanner;
@@ -54,7 +56,7 @@ class Callback
      *
      * @return array
      */
-    public function files()
+    public function files(): array
     {
         $files = [];
         foreach (call_user_func($this->callable) as $file) {
@@ -64,6 +66,7 @@ class Callback
             }
             $files[] = new Local($path);
         }
+
         return $files;
     }
 }

--- a/src/File/FileInterface.php
+++ b/src/File/FileInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -26,26 +28,26 @@ interface FileInterface
      *
      * @return string
      */
-    public function name();
+    public function name(): string;
 
     /**
      * Return contents of the file
      *
      * @return string
      */
-    public function contents();
+    public function contents(): string;
 
     /**
      * Return modified time of the file
      *
      * @return int
      */
-    public function modifiedTime();
+    public function modifiedTime(): int;
 
     /**
      * The path to the file.
      *
      * @return string
      */
-    public function path();
+    public function path(): string;
 }

--- a/src/File/Glob.php
+++ b/src/File/Glob.php
@@ -22,10 +22,10 @@ use RuntimeException;
  */
 class Glob
 {
-    protected $basePath;
-    protected $pattern;
+    protected string $basePath;
+    protected string $pattern;
 
-    public function __construct($basePath, $pattern)
+    public function __construct(string $basePath, string $pattern)
     {
         if (!is_dir($basePath)) {
             throw new RuntimeException("$basePath does not exist.");
@@ -37,7 +37,6 @@ class Glob
 
     /**
      * @return array<\MiniAsset\File\Local>
-     * @psalm-return list<\MiniAsset\File\Local>
      */
     public function files(): array
     {

--- a/src/File/Glob.php
+++ b/src/File/Glob.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,6 +15,8 @@
  */
 namespace MiniAsset\File;
 
+use RuntimeException;
+
 /**
  * Wrapper for glob patterns that are used in asset targets.
  */
@@ -24,7 +28,7 @@ class Glob
     public function __construct($basePath, $pattern)
     {
         if (!is_dir($basePath)) {
-            throw new \RuntimeException("$basePath does not exist.");
+            throw new RuntimeException("$basePath does not exist.");
         }
 
         $this->basePath = $basePath;
@@ -32,9 +36,8 @@ class Glob
     }
 
     /**
-     * @return Local[]
-     *
-     * @psalm-return list<Local>
+     * @return array<\MiniAsset\File\Local>
+     * @psalm-return list<\MiniAsset\File\Local>
      */
     public function files(): array
     {

--- a/src/File/Local.php
+++ b/src/File/Local.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,7 +15,7 @@
  */
 namespace MiniAsset\File;
 
-use MiniAsset\File\FileInterface;
+use RuntimeException;
 
 /**
  * Wrapper for local files that are used in asset targets.
@@ -25,13 +27,13 @@ class Local implements FileInterface
     public function __construct($path)
     {
         if (!is_file($path)) {
-            throw new \RuntimeException("$path does not exist.");
+            throw new RuntimeException("$path does not exist.");
         }
         $this->path = $path;
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function path()
     {
@@ -39,7 +41,7 @@ class Local implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function name()
     {
@@ -47,7 +49,7 @@ class Local implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function contents()
     {
@@ -55,7 +57,7 @@ class Local implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function modifiedTime()
     {

--- a/src/File/Local.php
+++ b/src/File/Local.php
@@ -22,9 +22,9 @@ use RuntimeException;
  */
 class Local implements FileInterface
 {
-    protected $path;
+    protected string $path;
 
-    public function __construct($path)
+    public function __construct(string $path)
     {
         if (!is_file($path)) {
             throw new RuntimeException("$path does not exist.");
@@ -32,34 +32,22 @@ class Local implements FileInterface
         $this->path = $path;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function path()
+    public function path(): string
     {
         return $this->path;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function name()
+    public function name(): string
     {
         return basename($this->path);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function contents()
+    public function contents(): string
     {
         return file_get_contents($this->path);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function modifiedTime()
+    public function modifiedTime(): int
     {
         return filemtime($this->path);
     }

--- a/src/File/Remote.php
+++ b/src/File/Remote.php
@@ -20,33 +20,24 @@ namespace MiniAsset\File;
  */
 class Remote implements FileInterface
 {
-    protected $url;
+    protected string $url;
 
-    public function __construct($url)
+    public function __construct(string $url)
     {
         $this->url = $url;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function path()
+    public function path(): string
     {
         return $this->url;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function name()
+    public function name(): string
     {
         return $this->url;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function contents()
+    public function contents(): string
     {
         $handle = fopen($this->url, 'rb');
         $content = '';
@@ -58,18 +49,15 @@ class Remote implements FileInterface
         return $content;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function modifiedTime()
+    public function modifiedTime(): int
     {
         return $this->_getLastModified($this->url);
     }
 
     /**
-     * @param string|false $url
+     * Get the last modified time from HTTP headers.
      */
-    protected function _getLastModified(false|string $url)
+    protected function _getLastModified(string $url): int|false
     {
         $time = time();
 

--- a/src/File/Remote.php
+++ b/src/File/Remote.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset\File;
 
-use MiniAsset\File\FileInterface;
-
 /**
  * Wrapper for remote files that are used in asset targets.
  */
@@ -28,7 +28,7 @@ class Remote implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function path()
     {
@@ -36,7 +36,7 @@ class Remote implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function name()
     {
@@ -44,7 +44,7 @@ class Remote implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function contents()
     {
@@ -54,11 +54,12 @@ class Remote implements FileInterface
             $content = stream_get_contents($handle);
             fclose($handle);
         }
+
         return $content;
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function modifiedTime()
     {
@@ -66,9 +67,9 @@ class Remote implements FileInterface
     }
 
     /**
-     * @param false|string $url
+     * @param string|false $url
      */
-    protected function _getLastModified($url)
+    protected function _getLastModified(false|string $url)
     {
         $time = time();
 
@@ -85,6 +86,7 @@ class Remote implements FileInterface
             if (substr(strtolower($response), 0, 10) === 'location: ') {
                 $newUri = substr($response, 10);
                 fclose($fp);
+
                 return $this->_getLastModified($newUri);
             } elseif (substr(strtolower($response), 0, 15) === 'last-modified: ') {
                 // last-modified found
@@ -94,6 +96,7 @@ class Remote implements FileInterface
         }
 
         fclose($fp);
+
         return $time;
     }
 }

--- a/src/File/Target.php
+++ b/src/File/Target.php
@@ -24,8 +24,8 @@ use MiniAsset\Output\CompilerInterface;
  */
 class Target implements FileInterface
 {
-    private $target;
-    private $compiler;
+    private AssetTarget $target;
+    private CompilerInterface $compiler;
 
     public function __construct(AssetTarget $target, CompilerInterface $compiler)
     {
@@ -33,34 +33,22 @@ class Target implements FileInterface
         $this->compiler = $compiler;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function path()
+    public function path(): string
     {
         return $this->target->path();
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function name()
+    public function name(): string
     {
         return $this->target->name();
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function contents()
+    public function contents(): string
     {
         return $this->compiler->generate($this->target);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function modifiedTime()
+    public function modifiedTime(): int
     {
         return $this->target->modifiedTime();
     }

--- a/src/File/Target.php
+++ b/src/File/Target.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -14,7 +16,6 @@
 namespace MiniAsset\File;
 
 use MiniAsset\AssetTarget;
-use MiniAsset\File\FileInterface;
 use MiniAsset\Output\CompilerInterface;
 
 /**
@@ -33,7 +34,7 @@ class Target implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function path()
     {
@@ -41,7 +42,7 @@ class Target implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function name()
     {
@@ -49,7 +50,7 @@ class Target implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function contents()
     {
@@ -57,7 +58,7 @@ class Target implements FileInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function modifiedTime()
     {

--- a/src/Filter/AssetFilter.php
+++ b/src/Filter/AssetFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -15,7 +17,6 @@ namespace MiniAsset\Filter;
 
 use MiniAsset\AssetProcess;
 use MiniAsset\AssetTarget;
-use MiniAsset\Filter\FilterInterface;
 use RuntimeException;
 
 /**
@@ -29,20 +30,21 @@ class AssetFilter implements FilterInterface
      *
      * @var array
      */
-    protected $_settings = array();
+    protected array $_settings = [];
 
     /**
      * Gets settings for this filter. Will always include 'paths'
      * key which points at paths available for the type of asset being generated.
      *
-     * @param  array $settings Array of settings.
+     * @param array $settings Array of settings.
      * @return array Array of updated settings.
      */
-    public function settings(array $settings = null)
+    public function settings(?array $settings = null): array
     {
         if ($settings) {
             $this->_settings = array_merge($this->_settings, $settings);
         }
+
         return $this->_settings;
     }
 
@@ -51,10 +53,9 @@ class AssetFilter implements FilterInterface
      *
      * @param string $filename Name of the file
      * @param string $content  Content of the file.
-     *
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         return $content;
     }
@@ -64,10 +65,9 @@ class AssetFilter implements FilterInterface
      *
      * @param string $target  The build target being made.
      * @param string $content The content to filter.
-     *
      * @return string
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         return $content;
     }
@@ -78,10 +78,10 @@ class AssetFilter implements FilterInterface
      * Preprocessor filters can use this hook method to find a list of dependent
      * files.
      *
-     * @param  \MiniAsset\AssetTarget $target The target to find dependencies for this filter.
+     * @param \MiniAsset\AssetTarget $target The target to find dependencies for this filter.
      * @return array An array of MiniAsset\File\Local objects.
      */
-    public function getDependencies(AssetTarget $target)
+    public function getDependencies(AssetTarget $target): array
     {
         return [];
     }
@@ -89,9 +89,9 @@ class AssetFilter implements FilterInterface
     /**
      * Overloaded in filters that can't handle dependencies
      *
-     * @return boolean True when the filter supports dependencies
+     * @return bool True when the filter supports dependencies
      */
-    public function hasDependencies()
+    public function hasDependencies(): bool
     {
         return true;
     }
@@ -102,12 +102,10 @@ class AssetFilter implements FilterInterface
      * @param string $cmd     The command to run.
      * @param string $content The content to run through the command.
      * @param array|null $environment
-     *
      * @return string The result of the command.
-     *
      * @throws \RuntimeException
      */
-    protected function _runCmd($cmd, $content, ?array $environment = null)
+    protected function _runCmd(string $cmd, string $content, ?array $environment = null): string
     {
         $Process = new AssetProcess();
         $Process->environment($environment);
@@ -116,6 +114,7 @@ class AssetFilter implements FilterInterface
         if ($Process->error()) {
             throw new RuntimeException($Process->error());
         }
+
         return $Process->output();
     }
 
@@ -125,10 +124,9 @@ class AssetFilter implements FilterInterface
      *
      * @param array  $search Paths to search.
      * @param string $file   The executable to find.
-     *
-     * @return null|string
+     * @return string|null
      */
-    protected function _findExecutable($search, $file): ?string
+    protected function _findExecutable(array $search, string $file): ?string
     {
         $file = str_replace('/', DIRECTORY_SEPARATOR, $file);
         if (file_exists($file)) {
@@ -140,6 +138,7 @@ class AssetFilter implements FilterInterface
                 return $path . DIRECTORY_SEPARATOR . $file;
             }
         }
+
         return null;
     }
 }

--- a/src/Filter/AssetFilter.php
+++ b/src/Filter/AssetFilter.php
@@ -53,7 +53,7 @@ class AssetFilter implements FilterInterface
      *
      * @param string $filename Name of the file
      * @param string $content  Content of the file.
-     * @return string
+     * @return void
      */
     public function input(string $filename, string $content): string
     {
@@ -79,7 +79,7 @@ class AssetFilter implements FilterInterface
      * files.
      *
      * @param \MiniAsset\AssetTarget $target The target to find dependencies for this filter.
-     * @return array An array of MiniAsset\File\Local objects.
+     * @return array<\MiniAsset\FileInterface> An array of MiniAsset\File\Local objects.
      */
     public function getDependencies(AssetTarget $target): array
     {
@@ -99,7 +99,7 @@ class AssetFilter implements FilterInterface
     /**
      * Run the compressor command and get the output
      *
-     * @param string $cmd     The command to run.
+     * @param string $cmd The command to run.
      * @param string $content The content to run through the command.
      * @param array|null $environment
      * @return string The result of the command.

--- a/src/Filter/ClosureCompiler.php
+++ b/src/Filter/ClosureCompiler.php
@@ -133,7 +133,7 @@ class ClosureCompiler extends AssetFilter
             CURLOPT_URL => 'https://closure-compiler.appspot.com/compile',
             CURLOPT_POST => 1,
             CURLOPT_POSTFIELDS => 'js_code=' . urlencode($content) . '&' . http_build_query($args),
-            CURLOPT_RETURNTRANSFER =>  1,
+            CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_HEADER => 0,
             CURLOPT_FOLLOWLOCATION => 0,
             ]

--- a/src/Filter/ClosureCompiler.php
+++ b/src/Filter/ClosureCompiler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,7 +15,7 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
+use Exception;
 
 /**
  * Google Closure Compiler API Filter
@@ -25,13 +27,12 @@ use MiniAsset\Filter\AssetFilter;
  */
 class ClosureCompiler extends AssetFilter
 {
-
     /**
      * Defaults.
      *
      * @var array
      */
-    protected $_defaults = array('compilation_level' => 'WHITESPACE_ONLY');
+    protected array $_defaults = ['compilation_level' => 'WHITESPACE_ONLY'];
 
     /**
      * Settings.
@@ -44,11 +45,11 @@ class ClosureCompiler extends AssetFilter
      *
      * @var array
      */
-    protected $_settings = array(
+    protected array $_settings = [
         'level' => null,
         'statistics' => false,
-        'warnings' => false
-    );
+        'warnings' => false,
+    ];
 
     /**
      * Optional API parameters.
@@ -59,36 +60,36 @@ class ClosureCompiler extends AssetFilter
      * @var array
      * @see https://developers.google.com/closure/compiler/docs/api-ref
      */
-    protected $_params = array(
+    protected array $_params = [
         'js_externs',
         'externs_url',
         'exclude_default_externs',
         'formatting',
         'use_closure_library',
-        'language'
-    );
+        'language',
+    ];
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @return string|true
      */
     public function output($target, $content)
     {
-        $errors = $this->_query($content, array('output_info' => 'errors'));
+        $errors = $this->_query($content, ['output_info' => 'errors']);
         if (!empty($errors)) {
-            throw new \Exception(sprintf("%s:\n%s\n", 'Errors', $errors));
+            throw new Exception(sprintf("%s:\n%s\n", 'Errors', $errors));
         }
 
-        $output = $this->_query($content, array('output_info' => 'compiled_code'));
+        $output = $this->_query($content, ['output_info' => 'compiled_code']);
 
         foreach ($this->_settings as $setting => $value) {
-            if (!in_array($setting, array('warnings', 'statistics')) || true != $value) {
+            if (!in_array($setting, ['warnings', 'statistics']) || $value != true) {
                 continue;
             }
 
-            $args = array('output_info' => $setting);
-            if ('warnings' == $setting && in_array($value, array('QUIET', 'DEFAULT', 'VERBOSE'))) {
+            $args = ['output_info' => $setting];
+            if ($setting == 'warnings' && in_array($value, ['QUIET', 'DEFAULT', 'VERBOSE'])) {
                 $args['warning_level'] = $value;
             }
 
@@ -104,16 +105,14 @@ class ClosureCompiler extends AssetFilter
      *
      * @param string $content Javascript to compile.
      * @param array  $args    API parameters.
-     *
      * @throws \Exception If curl extension is missing.
      * @throws \Exception If curl triggers an error.
-     *
      * @return string|true
      */
-    protected function _query($content, $args = array())
+    protected function _query(string $content, array $args = []): string|bool
     {
         if (!extension_loaded('curl')) {
-            throw new \Exception('Missing the `curl` extension.');
+            throw new Exception('Missing the `curl` extension.');
         }
 
         $args = array_merge($this->_defaults, $args);
@@ -130,23 +129,24 @@ class ClosureCompiler extends AssetFilter
         $ch = curl_init();
         curl_setopt_array(
             $ch,
-            array(
+            [
             CURLOPT_URL => 'https://closure-compiler.appspot.com/compile',
             CURLOPT_POST => 1,
             CURLOPT_POSTFIELDS => 'js_code=' . urlencode($content) . '&' . http_build_query($args),
             CURLOPT_RETURNTRANSFER =>  1,
             CURLOPT_HEADER => 0,
-            CURLOPT_FOLLOWLOCATION => 0
-            )
+            CURLOPT_FOLLOWLOCATION => 0,
+            ]
         );
 
         $output = curl_exec($ch);
 
-        if (false === $output) {
-            throw new \Exception('Curl error: ' . curl_error($ch));
+        if ($output === false) {
+            throw new Exception('Curl error: ' . curl_error($ch));
         }
 
         curl_close($ch);
+
         return $output;
     }
 }

--- a/src/Filter/ClosureJs.php
+++ b/src/Filter/ClosureJs.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,7 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
 use Exception;
 
 /**
@@ -25,26 +26,25 @@ use Exception;
  */
 class ClosureJs extends AssetFilter
 {
-
     /**
      * Settings for Closure based filters.
      *
      * @var array
      */
-    protected $_settings = array(
+    protected array $_settings = [
         'path' => 'closure/compiler.jar',
-        'warning_level' => 'QUIET' // Supress warnings by default
-    );
+        'warning_level' => 'QUIET', // Supress warnings by default
+    ];
 
     /**
      * Run $content through Closure compiler
      *
-     * @param  string $target Filename being generated.
-     * @param  string $content    Contents of file
+     * @param string $target Filename being generated.
+     * @param string $content    Contents of file
      * @throws \Exception $e
      * @return string Compressed file
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         $output = null;
         $paths = [getcwd(), dirname(dirname(dirname(dirname(__DIR__))))];
@@ -54,8 +54,8 @@ class ClosureJs extends AssetFilter
         $tmpFile = tempnam(sys_get_temp_dir(), 'CLOSURE');
         file_put_contents($tmpFile, $content);
 
-        $options = array('js' => $tmpFile) + $this->_settings;
-        $options = array_diff_key($options, array('path' => null, 'paths' => null, 'target' => null, 'theme' => null));
+        $options = ['js' => $tmpFile] + $this->_settings;
+        $options = array_diff_key($options, ['path' => null, 'paths' => null, 'target' => null, 'theme' => null]);
 
         $cmd = 'java -jar "' . $jar . '"';
         foreach ($options as $key => $value) {

--- a/src/Filter/ClosureJs.php
+++ b/src/Filter/ClosureJs.php
@@ -63,7 +63,7 @@ class ClosureJs extends AssetFilter
         }
 
         try {
-            $output = $this->_runCmd($cmd, null);
+            $output = $this->_runCmd($cmd, '');
         } catch (Exception $e) {
             //If there is an error need to remove tmpFile.
             // @codingStandardsIgnoreStart

--- a/src/Filter/CoffeeScript.php
+++ b/src/Filter/CoffeeScript.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-
 /**
  * Pre-processing filter that adds support for CoffeeScript files.
  *
@@ -24,28 +24,28 @@ use MiniAsset\Filter\AssetFilter;
  */
 class CoffeeScript extends AssetFilter
 {
-
-    protected $_settings = array(
+    protected $_settings = [
         'ext' => '.coffee',
         'coffee' => '/usr/local/bin/coffee',
         'node' => '/usr/local/bin/node',
-        'node_path' => '/usr/local/lib/node_modules'
-    );
+        'node_path' => '/usr/local/lib/node_modules',
+    ];
 
     /**
      * Runs `coffee` against files that match the configured extension.
      *
-     * @param  string $filename Filename being processed.
-     * @param  string $content  Content of the file being processed.
+     * @param string $filename Filename being processed.
+     * @param string $content  Content of the file being processed.
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
         }
         $cmd = $this->_settings['node'] . ' ' . $this->_settings['coffee'] . ' -c -p -s ';
-        $env = array('NODE_PATH' => $this->_settings['node_path']);
+        $env = ['NODE_PATH' => $this->_settings['node_path']];
+
         return $this->_runCmd($cmd, $content, $env);
     }
 }

--- a/src/Filter/CoffeeScript.php
+++ b/src/Filter/CoffeeScript.php
@@ -24,7 +24,7 @@ namespace MiniAsset\Filter;
  */
 class CoffeeScript extends AssetFilter
 {
-    protected $_settings = [
+    protected array $_settings = [
         'ext' => '.coffee',
         'coffee' => '/usr/local/bin/coffee',
         'node' => '/usr/local/bin/node',

--- a/src/Filter/CssCompressor.php
+++ b/src/Filter/CssCompressor.php
@@ -1,7 +1,7 @@
 <?php
-namespace MiniAsset\Filter;
+declare(strict_types=1);
 
-use MiniAsset\Filter\AssetFilter;
+namespace MiniAsset\Filter;
 
 /**
  * Output minifier for css-compressor
@@ -12,38 +12,37 @@ use MiniAsset\Filter\AssetFilter;
  */
 class CssCompressor extends AssetFilter
 {
-
-    protected $_settings = array(
+    protected $_settings = [
         'node' => '/usr/local/bin/node',
-        'node_path' => '/usr/local/lib/node_modules'
-    );
+        'node_path' => '/usr/local/lib/node_modules',
+    ];
 
     /**
      * Run `cleancss` against the output and compress it.
      *
-     * @param  string $target Name of the file being generated.
-     * @param  string $content    The uncompressed contents for $filename.
+     * @param string $target Name of the file being generated.
+     * @param string $content    The uncompressed contents for $filename.
      * @return string Compressed contents.
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
-        $env = array('NODE_PATH' => $this->_settings['node_path']);
+        $env = ['NODE_PATH' => $this->_settings['node_path']];
 
         $tmpfile = tempnam(sys_get_temp_dir(), 'miniasset_css_compressor');
         $this->generateScript($tmpfile, $content);
 
         $cmd = $this->_settings['node'] . ' ' . $tmpfile;
+
         return $this->_runCmd($cmd, '', $env);
     }
 
     /**
      * Generates a small bit of Javascript code to invoke cleancss with.
      *
-     * @param false|string $file
-     *
+     * @param string|false $file
      * @return void
      */
-    protected function generateScript($file, string $input): void
+    protected function generateScript(false|string $file, string $input): void
     {
         $script = <<<JS
 var csscompressor = require('css-compressor');

--- a/src/Filter/CssCompressor.php
+++ b/src/Filter/CssCompressor.php
@@ -12,7 +12,7 @@ namespace MiniAsset\Filter;
  */
 class CssCompressor extends AssetFilter
 {
-    protected $_settings = [
+    protected array $_settings = [
         'node' => '/usr/local/bin/node',
         'node_path' => '/usr/local/lib/node_modules',
     ];
@@ -21,7 +21,7 @@ class CssCompressor extends AssetFilter
      * Run `cleancss` against the output and compress it.
      *
      * @param string $target Name of the file being generated.
-     * @param string $content    The uncompressed contents for $filename.
+     * @param string $content The uncompressed contents for $filename.
      * @return string Compressed contents.
      */
     public function output(string $target, string $content): string

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -126,8 +126,7 @@ trait CssDependencyTrait
         $parts = explode($ds, $name);
         $filename = end($parts);
 
-        if (
-            $name === $filename ||
+        if ($name === $filename ||
             $filename[0] === $this->optionalDependencyPrefix
         ) {
             return $this->optionalDependencyPrefix . $name;

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -33,7 +33,7 @@ trait CssDependencyTrait
     /**
      * @inheritDoc
      */
-    public function getDependencies(AssetTarget $target, array $paths = [])
+    public function getDependencies(AssetTarget $target, array $paths = []): array
     {
         $prefixedName = '';
         $children = [];

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -126,8 +126,9 @@ trait CssDependencyTrait
         $parts = explode($ds, $name);
         $filename = end($parts);
 
-        if ($name === $filename
-            || $filename[0] === $this->optionalDependencyPrefix
+        if (
+            $name === $filename ||
+            $filename[0] === $this->optionalDependencyPrefix
         ) {
             return $this->optionalDependencyPrefix . $name;
         }

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -126,7 +126,8 @@ trait CssDependencyTrait
         $parts = explode($ds, $name);
         $filename = end($parts);
 
-        if ($name === $filename
+        if (
+            $name === $filename
             || $filename[0] === $this->optionalDependencyPrefix
         ) {
             return $this->optionalDependencyPrefix . $name;

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,6 +15,7 @@
  */
 namespace MiniAsset\Filter;
 
+use Exception;
 use MiniAsset\AssetTarget;
 use MiniAsset\File\Local;
 use MiniAsset\Utility\CssUtils;
@@ -28,7 +31,7 @@ use MiniAsset\Utility\CssUtils;
 trait CssDependencyTrait
 {
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getDependencies(AssetTarget $target, array $paths = [])
     {
@@ -47,7 +50,7 @@ trait CssDependencyTrait
 
             $deps = [];
             foreach ($imports as $name) {
-                if ('.css' === substr($name, -4)) {
+                if (substr($name, -4) === '.css') {
                     // skip normal css imports
                     continue;
                 }
@@ -72,7 +75,7 @@ trait CssDependencyTrait
                     $file = new Local($path);
                     $newTarget = new AssetTarget('phony.css', [$file]);
                     $children[] = $file;
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     // Do nothing, we just skip missing files.
                     // sometimes these are things like compass or bourbon
                     // internals.
@@ -86,16 +89,17 @@ trait CssDependencyTrait
                 }
             }
         }
+
         return $children;
     }
 
     /**
      * Attempt to locate a file in the configured paths.
      *
-     * @param  string $file The file to find.
+     * @param string $file The file to find.
      * @return string The resolved file.
      */
-    protected function _findFile($file)
+    protected function _findFile(string $file): string
     {
         foreach ($this->_settings['paths'] as $path) {
             $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
@@ -103,16 +107,17 @@ trait CssDependencyTrait
                 return $path . $file;
             }
         }
+
         return $file;
     }
 
     /**
      * Prepends filenames with defined prefix if not already defined.
      *
-     * @param  string $name The file name.
+     * @param string $name The file name.
      * @return string The prefixed filename.
      */
-    protected function _prependPrefixToFilename($name)
+    protected function _prependPrefixToFilename(string $name): string
     {
         if (!property_exists($this, 'optionalDependencyPrefix')) {
             return $name;
@@ -121,7 +126,8 @@ trait CssDependencyTrait
         $parts = explode($ds, $name);
         $filename = end($parts);
 
-        if ($name === $filename
+        if (
+            $name === $filename
             || $filename[0] === $this->optionalDependencyPrefix
         ) {
             return $this->optionalDependencyPrefix . $name;

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -126,8 +126,7 @@ trait CssDependencyTrait
         $parts = explode($ds, $name);
         $filename = end($parts);
 
-        if (
-            $name === $filename
+        if ($name === $filename
             || $filename[0] === $this->optionalDependencyPrefix
         ) {
             return $this->optionalDependencyPrefix . $name;

--- a/src/Filter/CssMinFilter.php
+++ b/src/Filter/CssMinFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,7 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
 use CssMin;
 use RuntimeException;
 
@@ -24,20 +25,20 @@ use RuntimeException;
  */
 class CssMinFilter extends AssetFilter
 {
-
     /**
      * Apply CssMin to $content.
      *
-     * @param  string $target   target filename
-     * @param  string $content  Content to filter.
+     * @param string $target   target filename
+     * @param string $content  Content to filter.
      * @throws \Exception
      * @return string
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         if (!class_exists('CssMin')) {
             throw new RuntimeException('Cannot not load filter class "CssMin". Ensure you have it installed.');
         }
+
         return CssMin::minify($content);
     }
 }

--- a/src/Filter/FilterCollection.php
+++ b/src/Filter/FilterCollection.php
@@ -24,7 +24,7 @@ use ReturnTypeWillChange;
  */
 class FilterCollection implements Countable
 {
-    protected $filters = [];
+    protected array $filters = [];
 
     public function __construct(array $filters)
     {

--- a/src/Filter/FilterCollection.php
+++ b/src/Filter/FilterCollection.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -14,6 +16,7 @@
 namespace MiniAsset\Filter;
 
 use Countable;
+use ReturnTypeWillChange;
 
 /**
  * FilterCollection objects are created by the FilterRegistry and allow
@@ -33,7 +36,7 @@ class FilterCollection implements Countable
      *
      * @return array
      */
-    public function filters()
+    public function filters(): array
     {
         return $this->filters;
     }
@@ -41,30 +44,32 @@ class FilterCollection implements Countable
     /**
      * Apply all the input filters in sequence to the file and content.
      *
-     * @param  string $file    Filename being processed.
-     * @param  string $content The content of the file.
+     * @param string $file    Filename being processed.
+     * @param string $content The content of the file.
      * @return string The content with all input filters applied.
      */
-    public function input($file, $content)
+    public function input(string $file, string $content): string
     {
         foreach ($this->filters as $filter) {
             $content = $filter->input($file, $content);
         }
+
         return $content;
     }
 
     /**
      * Apply all the output filters in sequence to the file and content.
      *
-     * @param  string $target    Filename being processed.
-     * @param  string $content The content of the file.
+     * @param string $target    Filename being processed.
+     * @param string $content The content of the file.
      * @return string The content with all output filters applied.
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         foreach ($this->filters as $filter) {
             $content = $filter->output($target, $content);
         }
+
         return $content;
     }
 
@@ -73,8 +78,8 @@ class FilterCollection implements Countable
      *
      * @return int
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    #[ReturnTypeWillChange]
+    public function count(): int
     {
         return count($this->filters);
     }

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -21,7 +23,6 @@ use MiniAsset\AssetTarget;
  */
 interface FilterInterface
 {
-
     /**
      * Input filters are used to do pre-processing on each file in a
      * build target.
@@ -29,7 +30,7 @@ interface FilterInterface
      * @param string $filename Name of the file
      * @param string $content  Content of the file.
      */
-    public function input($filename, $content);
+    public function input(string $filename, string $content): void;
 
     /**
      * Output filters are used to do minification or do other manipulation
@@ -38,16 +39,16 @@ interface FilterInterface
      * @param string $target  The build target being made.
      * @param string $content The content to filter.
      */
-    public function output($target, $content);
+    public function output(string $target, string $content): void;
 
     /**
      * Gets settings for this filter. Will always include 'paths'
      * key which points at paths available for the type of asset being generated.
      *
-     * @param  array $settings Array of settings.
+     * @param array $settings Array of settings.
      * @return array Updated Settings.
      */
-    public function settings(array $settings = null);
+    public function settings(?array $settings = null): array;
 
     /**
      * Find any additional filter based dependencies.
@@ -55,15 +56,15 @@ interface FilterInterface
      * Preprocessor filters can use this hook method to find a list of dependent
      * files. For example, `import` statements in Less/Sass.
      *
-     * @param  AssetTarget $target The target to find dependencies for this filter.
+     * @param \MiniAsset\AssetTarget $target The target to find dependencies for this filter.
      * @return array An array of MiniAsset\File\Local objects.
      */
-    public function getDependencies(AssetTarget $target);
+    public function getDependencies(AssetTarget $target): array;
 
     /**
      * Returns a boolean whether the filter supports dependencies.
      *
-     * @return boolean True when the filter supports dependencies
+     * @return bool True when the filter supports dependencies
      */
-    public function hasDependencies();
+    public function hasDependencies(): bool;
 }

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -29,8 +29,9 @@ interface FilterInterface
      *
      * @param string $filename Name of the file
      * @param string $content  Content of the file.
+     * @return string Modified contents
      */
-    public function input(string $filename, string $content): void;
+    public function input(string $filename, string $content): string;
 
     /**
      * Output filters are used to do minification or do other manipulation
@@ -38,8 +39,9 @@ interface FilterInterface
      *
      * @param string $target  The build target being made.
      * @param string $content The content to filter.
+     * @return string
      */
-    public function output(string $target, string $content): void;
+    public function output(string $target, string $content): string;
 
     /**
      * Gets settings for this filter. Will always include 'paths'

--- a/src/Filter/FilterRegistry.php
+++ b/src/Filter/FilterRegistry.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,9 +15,7 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\FilterInterface;
 use MiniAsset\AssetTarget;
-use MiniAsset\Filter\FilterCollection;
 use RuntimeException;
 
 /**
@@ -31,7 +31,7 @@ class FilterRegistry
      *
      * @var array
      */
-    protected $filters = [];
+    protected array $filters = [];
 
     /**
      * Constructor
@@ -48,10 +48,10 @@ class FilterRegistry
     /**
      * Check if the registry contains a named filter.
      *
-     * @param  string $name The filter name to check.
+     * @param string $name The filter name to check.
      * @return bool
      */
-    public function contains($name)
+    public function contains(string $name): bool
     {
         return isset($this->filters[$name]);
     }
@@ -59,11 +59,11 @@ class FilterRegistry
     /**
      * Add a filter to the registry
      *
-     * @param  string                            $name   The filter name to load.
-     * @param  \MiniAsset\Filter\FilterInterface $filter The filter to load.
+     * @param string                            $name   The filter name to load.
+     * @param \MiniAsset\Filter\FilterInterface $filter The filter to load.
      * @return void
      */
-    public function add($name, FilterInterface $filter)
+    public function add(string $name, FilterInterface $filter): void
     {
         $this->filters[$name] = $filter;
     }
@@ -71,24 +71,25 @@ class FilterRegistry
     /**
      * Get a filter from the registry
      *
-     * @param  string $name The filter name to fetch.
+     * @param string $name The filter name to fetch.
      * @return \MiniAsset\Filter\FilterInterface|null
      */
-    public function get($name)
+    public function get(string $name): ?FilterInterface
     {
         if (!isset($this->filters[$name])) {
             return null;
         }
+
         return $this->filters[$name];
     }
 
     /**
      * Remove a filter from the registry
      *
-     * @param  string $name The filter name to remove
+     * @param string $name The filter name to remove
      * @return void
      */
-    public function remove($name)
+    public function remove(string $name): void
     {
         unset($this->filters[$name]);
     }
@@ -96,10 +97,10 @@ class FilterRegistry
     /**
      * Get a filter collection for a specific target.
      *
-     * @param  \MiniAsset\AssetTarget $target The target to get a filter collection for.
+     * @param \MiniAsset\AssetTarget $target The target to get a filter collection for.
      * @return \MiniAsset\Filter\FilterCollection
      */
-    public function collection(AssetTarget $target)
+    public function collection(AssetTarget $target): FilterCollection
     {
         $filters = [];
         foreach ($target->filterNames() as $name) {
@@ -112,11 +113,12 @@ class FilterRegistry
             $copy->settings(
                 [
                 'target' => $target->name(),
-                'paths' => $target->paths()
+                'paths' => $target->paths(),
                 ]
             );
             $filters[] = $copy;
         }
+
         return new FilterCollection($filters);
     }
 }

--- a/src/Filter/FilterRegistry.php
+++ b/src/Filter/FilterRegistry.php
@@ -59,7 +59,7 @@ class FilterRegistry
     /**
      * Add a filter to the registry
      *
-     * @param string                            $name   The filter name to load.
+     * @param string $name The filter name to load.
      * @param \MiniAsset\Filter\FilterInterface $filter The filter to load.
      * @return void
      */

--- a/src/Filter/Hogan.php
+++ b/src/Filter/Hogan.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -12,8 +14,6 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace MiniAsset\Filter;
-
-use MiniAsset\Filter\AssetFilter;
 
 /**
  * Provides precompilation for mustache templates
@@ -30,26 +30,25 @@ use MiniAsset\Filter\AssetFilter;
  */
 class Hogan extends AssetFilter
 {
-
     /**
      * Settings for the filter.
      *
      * @var array
      */
-    protected $_settings = array(
+    protected array $_settings = [
         'ext' => '.mustache',
         'node' => '/usr/local/bin/node',
         'node_path' => '',
-    );
+    ];
 
     /**
      * Runs `hogan.compile` against all template fragments in a file.
      *
-     * @param  string $filename The name of the input file.
-     * @param  string $content    The content of the file.
+     * @param string $filename The name of the input file.
+     * @param string $content    The content of the file.
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
@@ -57,9 +56,10 @@ class Hogan extends AssetFilter
         $tmpfile = tempnam(sys_get_temp_dir(), 'mini_asset_hogan');
         $this->_generateScript($tmpfile, $filename, $content);
         $bin = $this->_settings['node'] . ' ' . $tmpfile;
-        $env = array('NODE_PATH' => $this->_settings['node_path']);
+        $env = ['NODE_PATH' => $this->_settings['node_path']];
         $return = $this->_runCmd($bin, '', $env);
         unlink($tmpfile);
+
         return $return;
     }
 
@@ -67,12 +67,12 @@ class Hogan extends AssetFilter
      * Generates the javascript passed into node to precompile the
      * the mustache template.
      *
-     * @param  string $file The tempfile to put the script in.
-     * @param  string $filename The template filename. Used to create a key in window.JST
-     * @param  string $input The mustache template content.
+     * @param string $file The tempfile to put the script in.
+     * @param string $filename The template filename. Used to create a key in window.JST
+     * @param string $input The mustache template content.
      * @return void
      */
-    protected function _generateScript($file, $filename, $input)
+    protected function _generateScript(string $file, string $filename, string $input): void
     {
         $id = str_replace($this->_settings['ext'], '', basename($filename));
         $filepath = str_replace($this->_settings['ext'], '', $filename);

--- a/src/Filter/ImportInline.php
+++ b/src/Filter/ImportInline.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,7 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
 use MiniAsset\AssetScanner;
 use RuntimeException;
 
@@ -24,7 +25,6 @@ use RuntimeException;
  */
 class ImportInline extends AssetFilter
 {
-
     protected $_pattern = '/^\s*@import\s*(?:(?:([\'"])([^\'"]+)\\1)|(?:url\(([\'"])([^\'"]+)\\3\)));/m';
 
     protected $scanner = null;
@@ -37,21 +37,22 @@ class ImportInline extends AssetFilter
             return $this->scanner;
         }
         $this->scanner = new AssetScanner($this->_settings['paths']);
+
         return $this->scanner;
     }
 
     /**
      * Preprocesses CSS files and replaces @import statements.
      *
-     * @param  string $filename
-     * @param  string $content
+     * @param string $filename
+     * @param string $content
      * @return string The processed file.
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         return preg_replace_callback(
             $this->_pattern,
-            array($this, '_replace'),
+            [$this, '_replace'],
             $content
         );
     }
@@ -60,12 +61,10 @@ class ImportInline extends AssetFilter
      * Does file replacements.
      *
      * @param array $matches
-     *
      * @throws \RuntimeException
-     *
      * @return string
      */
-    protected function _replace($matches): string
+    protected function _replace(array $matches): string
     {
         $required = empty($matches[2]) ? $matches[4] : $matches[2];
         $filename = $this->scanner()->find($required);
@@ -75,6 +74,7 @@ class ImportInline extends AssetFilter
         if (empty($this->_loaded[$filename])) {
             return $this->input($filename, file_get_contents($filename));
         }
+
         return '';
     }
 }

--- a/src/Filter/ImportInline.php
+++ b/src/Filter/ImportInline.php
@@ -25,13 +25,13 @@ use RuntimeException;
  */
 class ImportInline extends AssetFilter
 {
-    protected $_pattern = '/^\s*@import\s*(?:(?:([\'"])([^\'"]+)\\1)|(?:url\(([\'"])([^\'"]+)\\3\)));/m';
+    protected string $_pattern = '/^\s*@import\s*(?:(?:([\'"])([^\'"]+)\\1)|(?:url\(([\'"])([^\'"]+)\\3\)));/m';
 
-    protected $scanner = null;
+    protected ?AssetScanner $scanner = null;
 
-    protected $_loaded = [];
+    protected array $_loaded = [];
 
-    protected function scanner()
+    protected function scanner(): AssetScanner
     {
         if (isset($this->scanner)) {
             return $this->scanner;

--- a/src/Filter/JShrinkFilter.php
+++ b/src/Filter/JShrinkFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,7 +15,7 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
+use Exception;
 use JShrink\Minifier;
 
 /**
@@ -25,30 +27,30 @@ use JShrink\Minifier;
  */
 class JShrinkFilter extends AssetFilter
 {
-
     /**
      * Settings for JShrink minifier.
      *
      * @var array
      */
-    protected $_settings = array(
+    protected array $_settings = [
         'path' => 'jshrink/Minifier.php',
         'flaggedComments' => true,
-    );
+    ];
 
     /**
      * Apply JShrink to $content.
      *
-     * @param  string $target target filename
-     * @param  string $content  Content to filter.
+     * @param string $target target filename
+     * @param string $content  Content to filter.
      * @throws \Exception
      * @return string
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         if (!class_exists('JShrink\Minifier')) {
-            throw new \Exception(sprintf('Cannot not load filter class "%s".', 'JShrink\Minifier'));
+            throw new Exception(sprintf('Cannot not load filter class "%s".', 'JShrink\Minifier'));
         }
-        return Minifier::minify($content, array('flaggedComments' => $this->_settings['flaggedComments']));
+
+        return Minifier::minify($content, ['flaggedComments' => $this->_settings['flaggedComments']]);
     }
 }

--- a/src/Filter/JSqueezeFilter.php
+++ b/src/Filter/JSqueezeFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,7 +15,7 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
+use Exception;
 use Patchwork\JSqueeze;
 
 /**
@@ -25,30 +27,29 @@ use Patchwork\JSqueeze;
  */
 class JSqueezeFilter extends AssetFilter
 {
-
     /**
      * Settings for JSqueeze minifier.
      *
      * @var array
      */
-    protected $_settings = [
+    protected array $_settings = [
         'singleLine' => true,
         'keepImportantComments' => true,
-        'specialVarRx' => false
+        'specialVarRx' => false,
     ];
 
     /**
      * Apply JSqueeze to $content.
      *
-     * @param  string $target target filename
-     * @param  string $content  Content to filter.
+     * @param string $target target filename
+     * @param string $content  Content to filter.
      * @throws \Exception
      * @return string
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         if (!class_exists('Patchwork\JSqueeze')) {
-            throw new \Exception(sprintf('Cannot not load filter class "%s".', 'Patchwork\JSqueeze'));
+            throw new Exception(sprintf('Cannot not load filter class "%s".', 'Patchwork\JSqueeze'));
         }
 
         $jz = new JSqueeze();

--- a/src/Filter/JsMinFilter.php
+++ b/src/Filter/JsMinFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,8 @@
  */
 namespace MiniAsset\Filter;
 
+use Exception;
 use JSMin;
-use MiniAsset\Filter\AssetFilter;
 
 /**
  * JsMin filter.
@@ -30,23 +32,23 @@ use MiniAsset\Filter\AssetFilter;
  */
 class JsMinFilter extends AssetFilter
 {
-
     /**
      * Apply JsMin to $content.
      *
-     * @param  string $target Name of the file being generated.
-     * @param  string $content  The uncompress contents of $target.
+     * @param string $target Name of the file being generated.
+     * @param string $content  The uncompress contents of $target.
      * @throws \Exception
      * @return string
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         if (function_exists('jsmin')) {
             return jsmin($content);
         }
         if (!class_exists('JSMin')) {
-            throw new \Exception(sprintf('Cannot not load filter class "%s".', 'JsMin'));
+            throw new Exception(sprintf('Cannot not load filter class "%s".', 'JsMin'));
         }
+
         return JSMin::minify($content);
     }
 }

--- a/src/Filter/LessCss.php
+++ b/src/Filter/LessCss.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,9 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-use MiniAsset\Filter\CssDependencyTrait;
-
 /**
  * Pre-processing filter that adds support for LESS.css files.
  *
@@ -27,21 +26,21 @@ class LessCss extends AssetFilter
 {
     use CssDependencyTrait;
 
-    protected $_settings = array(
+    protected $_settings = [
         'ext' => '.less',
         'node' => '/usr/local/bin/node',
         'node_path' => '/usr/local/lib/node_modules',
         'paths' => [],
-    );
+    ];
 
     /**
      * Runs `lessc` against any files that match the configured extension.
      *
-     * @param  string $filename The name of the input file.
-     * @param  string $content    The content of the file.
+     * @param string $filename The name of the input file.
+     * @param string $content    The content of the file.
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
@@ -51,9 +50,10 @@ class LessCss extends AssetFilter
         $this->_generateScript($tmpfile, $content);
 
         $bin = $this->_settings['node'] . ' ' . $tmpfile;
-        $env = array('NODE_PATH' => $this->_settings['node_path']);
+        $env = ['NODE_PATH' => $this->_settings['node_path']];
         $return = $this->_runCmd($bin, '', $env);
         unlink($tmpfile);
+
         return $return;
     }
 

--- a/src/Filter/LessCss.php
+++ b/src/Filter/LessCss.php
@@ -26,7 +26,7 @@ class LessCss extends AssetFilter
 {
     use CssDependencyTrait;
 
-    protected $_settings = [
+    protected array $_settings = [
         'ext' => '.less',
         'node' => '/usr/local/bin/node',
         'node_path' => '/usr/local/lib/node_modules',
@@ -57,7 +57,7 @@ class LessCss extends AssetFilter
         return $return;
     }
 
-    protected function _generateScript($file, string $content): void
+    protected function _generateScript(string $file, string $content): void
     {
         $text = <<<JS
 var less = require('less'),

--- a/src/Filter/LessDotPHP.php
+++ b/src/Filter/LessDotPHP.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,6 +15,9 @@
  */
 namespace MiniAsset\Filter;
 
+use Exception;
+use Less_Parser;
+
 /**
  * Pre-processing filter that adds support for LESS.css files.
  *
@@ -24,30 +29,30 @@ class LessDotPHP extends AssetFilter
 {
     use CssDependencyTrait;
 
-    protected $_settings = array(
+    protected $_settings = [
         'ext' => '.less',
         'paths' => [],
-    );
+    ];
 
     /**
      * Runs `lessc` against any files that match the configured extension.
      *
-     * @param  string $filename The name of the input file.
-     * @param  string $content    The content of the file.
+     * @param string $filename The name of the input file.
+     * @param string $content    The content of the file.
      * @return string
      * @throws \Exception
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
         }
         if (!class_exists('\Less_Parser')) {
-            throw new \Exception(
+            throw new Exception(
                 'Cannot not load "\Less_Parser" class. Make sure https://github.com/oyejorge/less.php is installed.'
             );
         }
-        $parser = new \Less_Parser();
+        $parser = new Less_Parser();
 
         return $parser->parseFile($filename)->getCss();
     }

--- a/src/Filter/LessDotPHP.php
+++ b/src/Filter/LessDotPHP.php
@@ -29,7 +29,7 @@ class LessDotPHP extends AssetFilter
 {
     use CssDependencyTrait;
 
-    protected $_settings = [
+    protected array $_settings = [
         'ext' => '.less',
         'paths' => [],
     ];

--- a/src/Filter/LessPHP.php
+++ b/src/Filter/LessPHP.php
@@ -29,7 +29,7 @@ class LessPHP extends AssetFilter
 {
     use CssDependencyTrait;
 
-    protected $_settings = [
+    protected array $_settings = [
         'ext' => '.less',
         'paths' => [],
     ];

--- a/src/Filter/LessPHP.php
+++ b/src/Filter/LessPHP.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,7 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-use MiniAsset\Filter\CssDependencyTrait;
+use Exception;
 use lessc;
 
 /**
@@ -28,28 +29,29 @@ class LessPHP extends AssetFilter
 {
     use CssDependencyTrait;
 
-    protected $_settings = array(
+    protected $_settings = [
         'ext' => '.less',
         'paths' => [],
-    );
+    ];
 
     /**
      * Runs `lessc` against any files that match the configured extension.
      *
-     * @param  string $filename The name of the input file.
-     * @param  string $content    The content of the file.
+     * @param string $filename The name of the input file.
+     * @param string $content    The content of the file.
      * @throws \Exception
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
         }
         if (!class_exists('lessc')) {
-            throw new \Exception('Cannot not load "lessc" class. Make sure it is installed.');
+            throw new Exception('Cannot not load "lessc" class. Make sure it is installed.');
         }
         $lc = new lessc($filename);
+
         return $lc->parse();
     }
 }

--- a/src/Filter/MinifyFilter.php
+++ b/src/Filter/MinifyFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace MiniAsset\Filter;
 
 use MatthiasMullie\Minify;
@@ -13,12 +15,12 @@ class MinifyFilter extends AssetFilter
     /**
      * Run $content through Minify.
      *
-     * @param  string $target target filename
-     * @param  string $content  Content to filter.
+     * @param string $target target filename
+     * @param string $content  Content to filter.
      * @throws \Exception
      * @return string
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         if (substr($target, -3) === 'css') {
             return (new Minify\CSS($content))->minify();

--- a/src/Filter/PipeInputFilter.php
+++ b/src/Filter/PipeInputFilter.php
@@ -35,7 +35,7 @@ class PipeInputFilter extends AssetFilter
      * - `command` Command to run the file through
      * - `path` Sets PATH environment variable
      */
-    protected $_settings = [
+    protected array $_settings = [
         'ext' => '.css',
         'dependencies' => false,
         'optional_dependency_prefix' => false,
@@ -46,16 +46,19 @@ class PipeInputFilter extends AssetFilter
     /**
      * It will use prefixed files if they exist.
      *
-     * @var string
+     * @var ?string
      */
-    protected string $optionalDependencyPrefix = null;
+    protected ?string $optionalDependencyPrefix = null;
 
-    public function hasDependencies()
+    public function hasDependencies(): bool
     {
         return $this->_settings['dependencies'];
     }
 
-    public function getDependencies(AssetTarget $target)
+    /**
+     * @return array<\MiniAsset\AssetTarget>
+     */
+    public function getDependencies(AssetTarget $target): array
     {
         if ($this->_settings['dependencies']) {
             $this->optionalDependencyPrefix = $this->_settings['optional_dependency_prefix'];

--- a/src/Filter/PipeInputFilter.php
+++ b/src/Filter/PipeInputFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -14,8 +16,6 @@
 namespace MiniAsset\Filter;
 
 use MiniAsset\AssetTarget;
-use MiniAsset\Filter\AssetFilter;
-use MiniAsset\Filter\CssDependencyTrait;
 
 /**
  * Pre-processing filter that adds support for command pipes
@@ -35,20 +35,20 @@ class PipeInputFilter extends AssetFilter
      * - `command` Command to run the file through
      * - `path` Sets PATH environment variable
      */
-    protected $_settings = array(
+    protected $_settings = [
         'ext' => '.css',
         'dependencies' => false,
         'optional_dependency_prefix' => false,
         'command' => '/bin/cat',
         'path' => '/bin',
-    );
+    ];
 
     /**
      * It will use prefixed files if they exist.
      *
      * @var string
      */
-    protected $optionalDependencyPrefix = null;
+    protected string $optionalDependencyPrefix = null;
 
     public function hasDependencies()
     {
@@ -73,14 +73,14 @@ class PipeInputFilter extends AssetFilter
      * @param string $content The content of the file.
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
         }
         $filename = escapeshellarg($filename);
         $bin = $this->_settings['command'] . ' ' . $filename;
-        $return = $this->_runCmd($bin, '', array('PATH' => $this->_settings['path']));
+        $return = $this->_runCmd($bin, '', ['PATH' => $this->_settings['path']]);
 
         return $return;
     }

--- a/src/Filter/PipeOutputFilter.php
+++ b/src/Filter/PipeOutputFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,23 +15,20 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-
 /**
  * Output pipe processor
  */
 class PipeOutputFilter extends AssetFilter
 {
-
     /**
      * Settings for PipeOutputFilter
      *
      * - `command` Command to execute
      */
-    protected $_settings = array(
+    protected $_settings = [
         'command' => '/bin/cat',
         'path' => '/bin',
-    );
+    ];
 
     /**
      * Run command against the output and compress it.
@@ -38,10 +37,10 @@ class PipeOutputFilter extends AssetFilter
      * @param string $content The raw contents for $filename.
      * @return string Processed contents.
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         $cmd = $this->_settings['command'];
 
-        return $this->_runCmd($cmd, $content, array('PATH' => $this->_settings['path']));
+        return $this->_runCmd($cmd, $content, ['PATH' => $this->_settings['path']]);
     }
 }

--- a/src/Filter/PipeOutputFilter.php
+++ b/src/Filter/PipeOutputFilter.php
@@ -25,7 +25,7 @@ class PipeOutputFilter extends AssetFilter
      *
      * - `command` Command to execute
      */
-    protected $_settings = [
+    protected array $_settings = [
         'command' => '/bin/cat',
         'path' => '/bin',
     ];

--- a/src/Filter/ScssFilter.php
+++ b/src/Filter/ScssFilter.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace MiniAsset\Filter;
 
+use MiniAsset\AssetTarget;
+
 /**
  * Pre-processing filter that adds support for SCSS files.
  *
@@ -28,7 +30,7 @@ class ScssFilter extends AssetFilter
         getDependencies as getCssDependencies;
     }
 
-    protected $_settings = [
+    protected array $_settings = [
         'ext' => '.scss',
         'sass' => '/usr/bin/sass',
         'path' => '/usr/bin',
@@ -42,7 +44,10 @@ class ScssFilter extends AssetFilter
      */
     protected string $optionalDependencyPrefix = '_';
 
-    public function getDependencies($target)
+    /**
+     * @return array<\MiniAsset\File\FileInterface>
+     */
+    public function getDependencies(AssetTarget $target): array
     {
         return $this->getCssDependencies($target, $this->_settings['imports']);
     }

--- a/src/Filter/ScssFilter.php
+++ b/src/Filter/ScssFilter.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,9 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-use MiniAsset\Filter\CssDependencyTrait;
-
 /**
  * Pre-processing filter that adds support for SCSS files.
  *
@@ -29,19 +28,19 @@ class ScssFilter extends AssetFilter
         getDependencies as getCssDependencies;
     }
 
-    protected $_settings = array(
+    protected $_settings = [
         'ext' => '.scss',
         'sass' => '/usr/bin/sass',
         'path' => '/usr/bin',
         'imports' => [],
-    );
+    ];
 
     /**
      * SCSS will use `_` prefixed files if they exist.
      *
      * @var string
      */
-    protected $optionalDependencyPrefix = '_';
+    protected string $optionalDependencyPrefix = '_';
 
     public function getDependencies($target)
     {
@@ -51,11 +50,11 @@ class ScssFilter extends AssetFilter
     /**
      * Runs SCSS compiler against any files that match the configured extension.
      *
-     * @param  string $filename The name of the input file.
-     * @param  string $content    The content of the file.
+     * @param string $filename The name of the input file.
+     * @param string $content    The content of the file.
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
@@ -66,7 +65,8 @@ class ScssFilter extends AssetFilter
             $cmd .= ' -I ' . escapeshellarg($path);
         }
         $bin = $cmd . ' ' . $filename;
-        $return = $this->_runCmd($bin, '', array('PATH' => $this->_settings['path']));
+        $return = $this->_runCmd($bin, '', ['PATH' => $this->_settings['path']]);
+
         return $return;
     }
 }

--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace MiniAsset\Filter;
 
 use Exception;
+use MiniAsset\AssetTarget;
 use ScssPhp\ScssPhp\Compiler;
 
 /**
@@ -31,7 +32,7 @@ class ScssPHP extends AssetFilter
         getDependencies as getCssDependencies;
     }
 
-    protected $_settings = [
+    protected array $_settings = [
         'ext' => '.scss',
         'imports' => [],
     ];
@@ -43,14 +44,17 @@ class ScssPHP extends AssetFilter
      */
     protected string $optionalDependencyPrefix = '_';
 
-    public function getDependencies($target)
+    /**
+     * @return array<\MiniAsset\File\FileInterface>
+     */
+    public function getDependencies(AssetTarget $target): array
     {
         return $this->getCssDependencies($target, $this->_settings['imports']);
     }
 
     /**
      * @param string $filename The name of the input file.
-     * @param string $content    The content of the file.
+     * @param string $content The content of the file.
      * @throws \Exception
      * @return string
      */

--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,7 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-use MiniAsset\Filter\CssDependencyTrait;
+use Exception;
 use ScssPhp\ScssPhp\Compiler;
 
 /**
@@ -30,17 +31,17 @@ class ScssPHP extends AssetFilter
         getDependencies as getCssDependencies;
     }
 
-    protected $_settings = array(
+    protected $_settings = [
         'ext' => '.scss',
         'imports' => [],
-    );
+    ];
 
     /**
      * SCSS will use `_` prefixed files if they exist.
      *
      * @var string
      */
-    protected $optionalDependencyPrefix = '_';
+    protected string $optionalDependencyPrefix = '_';
 
     public function getDependencies($target)
     {
@@ -48,24 +49,25 @@ class ScssPHP extends AssetFilter
     }
 
     /**
-     * @param  string $filename The name of the input file.
-     * @param  string $content    The content of the file.
+     * @param string $filename The name of the input file.
+     * @param string $content    The content of the file.
      * @throws \Exception
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
         }
         if (!class_exists('ScssPhp\\ScssPhp\\Compiler')) {
-            throw new \Exception(sprintf('Cannot not load filter class "%s".', 'ScssPhp\\ScssPhp\\Compiler'));
+            throw new Exception(sprintf('Cannot not load filter class "%s".', 'ScssPhp\\ScssPhp\\Compiler'));
         }
         $sc = new Compiler();
         $sc->addImportPath(dirname($filename));
         foreach ($this->_settings['imports'] as $path) {
             $sc->addImportPath($path);
         }
+
         return $sc->compile($content);
     }
 }

--- a/src/Filter/SimpleCssMin.php
+++ b/src/Filter/SimpleCssMin.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-
 /**
  * SimpleCssMin filter.
  * Easily compresses CSS files. Allows to avoid problems that some minifiers have
@@ -22,7 +22,6 @@ use MiniAsset\Filter\AssetFilter;
  */
 class SimpleCssMin extends AssetFilter
 {
-
     /**
      * Apply SimpleCssMin to $content.
      *
@@ -30,11 +29,11 @@ class SimpleCssMin extends AssetFilter
      * Copyright (c) 2009 and onwards, Manas Tungare.
      * Creative Commons Attribution, Share-Alike.
      *
-     * @param  string $target target filename
-     * @param  string $content  Content to filter.
+     * @param string $target target filename
+     * @param string $content  Content to filter.
      * @return string
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         // Remove comments
         $content = preg_replace('!/\*[^*]*\*+([^/][^*]*\*+)*/!', '', $content);

--- a/src/Filter/Sprockets.php
+++ b/src/Filter/Sprockets.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,10 +15,10 @@
  */
 namespace MiniAsset\Filter;
 
+use Exception;
 use MiniAsset\AssetScanner;
 use MiniAsset\AssetTarget;
 use MiniAsset\File\Local;
-use MiniAsset\Filter\AssetFilter;
 
 /**
  * Implements directive replacement similar to sprockets <http://getsprockets.org>
@@ -24,7 +26,6 @@ use MiniAsset\Filter\AssetFilter;
  */
 class Sprockets extends AssetFilter
 {
-
     protected $_scanner;
 
     /**
@@ -32,21 +33,21 @@ class Sprockets extends AssetFilter
      *
      * @var string
      */
-    protected $_pattern = '/^\s?\/\/\=\s+require\s+([\"\<])([^\"\>]+)[\"\>](?:[\r\n]+|[\n]+)/m';
+    protected string $_pattern = '/^\s?\/\/\=\s+require\s+([\"\<])([^\"\>]+)[\"\>](?:[\r\n]+|[\n]+)/m';
 
     /**
      * A list of unique files already processed.
      *
      * @var array
      */
-    protected $_loaded = array();
+    protected array $_loaded = [];
 
     /**
      * The current file being processed, used for "" file inclusion.
      *
      * @var string
      */
-    protected $_currentFile = '';
+    protected string $_currentFile = '';
 
     protected function _scanner()
     {
@@ -54,22 +55,24 @@ class Sprockets extends AssetFilter
             return $this->_scanner;
         }
         $this->_scanner = new AssetScanner($this->_settings['paths']);
+
         return $this->_scanner;
     }
 
     /**
      * Input filter - preprocesses //=require statements
      *
-     * @param  string $filename
-     * @param  string $content
+     * @param string $filename
+     * @param string $content
      * @return string content
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         $this->_currentFile = $filename;
+
         return preg_replace_callback(
             $this->_pattern,
-            array($this, '_replace'),
+            [$this, '_replace'],
             $content
         );
     }
@@ -77,10 +80,10 @@ class Sprockets extends AssetFilter
     /**
      * Performs the replacements and inlines dependencies.
      *
-     * @param  array $matches
+     * @param array $matches
      * @return string content
      */
-    protected function _replace($matches)
+    protected function _replace(array $matches): string
     {
         $file = $this->_currentFile;
         if ($matches[1] === '"') {
@@ -93,7 +96,7 @@ class Sprockets extends AssetFilter
 
         // prevent double inclusion
         if (isset($this->_loaded[$file])) {
-            return "";
+            return '';
         }
         $this->_loaded[$file] = true;
 
@@ -101,18 +104,19 @@ class Sprockets extends AssetFilter
         if ($return = $this->input($file, $content)) {
             return $return . "\n";
         }
+
         return '';
     }
 
     /**
      * Locates sibling files, or uses AssetScanner to locate <> style dependencies.
      *
-     * @param  string $filename The basename of the file needing to be found.
-     * @param  string $path     The path for same directory includes.
+     * @param string $filename The basename of the file needing to be found.
+     * @param string $path     The path for same directory includes.
      * @return string Path to file.
      * @throws \Exception when files can't be located.
      */
-    protected function _findFile($filename, $path = null)
+    protected function _findFile(string $filename, ?string $path = null): string
     {
         if (substr($filename, -2) !== 'js') {
             $filename .= '.js';
@@ -124,11 +128,11 @@ class Sprockets extends AssetFilter
         if ($file) {
             return $file;
         }
-        throw new \Exception('Sprockets - Could not locate file "' . $filename . '"');
+        throw new Exception('Sprockets - Could not locate file "' . $filename . '"');
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getDependencies(AssetTarget $target)
     {
@@ -153,6 +157,7 @@ class Sprockets extends AssetFilter
                 $children = array_merge($children, $this->getDependencies($newTarget));
             }
         }
+
         return $children;
     }
 }

--- a/src/Filter/Sprockets.php
+++ b/src/Filter/Sprockets.php
@@ -26,7 +26,7 @@ use MiniAsset\File\Local;
  */
 class Sprockets extends AssetFilter
 {
-    protected $_scanner;
+    protected ?AssetScanner $_scanner;
 
     /**
      * Regex pattern for finding //= require <file> and //= require "file" style inclusions
@@ -49,7 +49,7 @@ class Sprockets extends AssetFilter
      */
     protected string $_currentFile = '';
 
-    protected function _scanner()
+    protected function _scanner(): AssetScanner
     {
         if (isset($this->_scanner)) {
             return $this->_scanner;
@@ -101,7 +101,8 @@ class Sprockets extends AssetFilter
         $this->_loaded[$file] = true;
 
         $content = file_get_contents($file);
-        if ($return = $this->input($file, $content)) {
+        $return = $this->input($file, $content);
+        if (strlen($return)) {
             return $return . "\n";
         }
 
@@ -134,7 +135,7 @@ class Sprockets extends AssetFilter
     /**
      * @inheritDoc
      */
-    public function getDependencies(AssetTarget $target)
+    public function getDependencies(AssetTarget $target): array
     {
         $children = [];
         foreach ($target->files() as $file) {

--- a/src/Filter/TimestampImage.php
+++ b/src/Filter/TimestampImage.php
@@ -37,9 +37,9 @@ class TimestampImage extends AssetFilter
      */
     protected string $_backgroundImagePattern = '/^(?<prop>.*background-image\s*\:\s*url\([\'"]?)(?<path>[^\'")]+?(?:png|gif|jpg))(?<trail>[\'"]?\))/m';
 
-    protected $_filename;
+    protected string $_filename;
 
-    protected $_settings = [
+    protected array $_settings = [
         'webroot' => '',
     ];
 

--- a/src/Filter/TimestampImage.php
+++ b/src/Filter/TimestampImage.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-
 /**
  * Adds timestamp querystrings to all background images in CSS files.
  * This helps with cachebusting CSS sprites. This is useful in
@@ -23,40 +23,39 @@ use MiniAsset\Filter\AssetFilter;
  */
 class TimestampImage extends AssetFilter
 {
-
     /**
      * Regex for `background` CSS property.
      *
      * @var string
      */
-    protected $_backgroundPattern = '/^(?<prop>.*background\s*\:\s*(?:\#[a-f0-9A-F]{3,6})?\s*url\([\'"]?)(?<path>[^\'")]+?(?:png|gif|jpg))(?<trail>[\'"]?\))/m';
+    protected string $_backgroundPattern = '/^(?<prop>.*background\s*\:\s*(?:\#[a-f0-9A-F]{3,6})?\s*url\([\'"]?)(?<path>[^\'")]+?(?:png|gif|jpg))(?<trail>[\'"]?\))/m';
 
     /**
      * Regex for `background-image` CSS property.
      *
      * @var string
      */
-    protected $_backgroundImagePattern = '/^(?<prop>.*background-image\s*\:\s*url\([\'"]?)(?<path>[^\'")]+?(?:png|gif|jpg))(?<trail>[\'"]?\))/m';
+    protected string $_backgroundImagePattern = '/^(?<prop>.*background-image\s*\:\s*url\([\'"]?)(?<path>[^\'")]+?(?:png|gif|jpg))(?<trail>[\'"]?\))/m';
 
     protected $_filename;
 
     protected $_settings = [
-        'webroot' => ''
+        'webroot' => '',
     ];
 
     /**
      * Input filter. Locates CSS background images relative to the
      * filename and gets the filemtime for the images.
      *
-     * @param  string $filename The file being processed
-     * @param  string $content  The file content
+     * @param string $filename The file being processed
+     * @param string $content  The file content
      * @return string The content with images timestamped.
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         $this->_filename = $filename;
-        $content = preg_replace_callback($this->_backgroundPattern, array($this, '_replace'), $content);
-        $content = preg_replace_callback($this->_backgroundImagePattern, array($this, '_replace'), $content);
+        $content = preg_replace_callback($this->_backgroundPattern, [$this, '_replace'], $content);
+        $content = preg_replace_callback($this->_backgroundImagePattern, [$this, '_replace'], $content);
 
         return $content;
     }
@@ -70,10 +69,10 @@ class TimestampImage extends AssetFilter
      * If the image path starts with / its assumed to be an absolute path
      * which will be prepended with settings[webroot] or WWW_ROOT
      *
-     * @param  array $matches Array of matches
+     * @param array $matches Array of matches
      * @return string Replaced code.
      */
-    protected function _replace($matches)
+    protected function _replace(array $matches): string
     {
         $webroot = null;
         if (defined('WWW_ROOT')) {
@@ -92,6 +91,7 @@ class TimestampImage extends AssetFilter
         if (file_exists($imagePath)) {
             $path = $this->_timestamp($imagePath, $path);
         }
+
         return $matches['prop'] . $path . $matches['trail'];
     }
 
@@ -100,15 +100,16 @@ class TimestampImage extends AssetFilter
      * querystrings, as they could have anything in them or be customized
      * already.
      *
-     * @param  string $filepath The absolute path to the file for timestamping
-     * @param  string $path     The path to append a timestamp to.
+     * @param string $filepath The absolute path to the file for timestamping
+     * @param string $path     The path to append a timestamp to.
      * @return string Path with a timestamp.
      */
-    protected function _timestamp($filepath, $path)
+    protected function _timestamp(string $filepath, string $path): string
     {
         if (strpos($path, '?') === false) {
             $path .= '?t=' . filemtime($filepath);
         }
+
         return $path;
     }
 }

--- a/src/Filter/TypeScript.php
+++ b/src/Filter/TypeScript.php
@@ -22,7 +22,7 @@ namespace MiniAsset\Filter;
  */
 class TypeScript extends AssetFilter
 {
-    protected $_settings = [
+    protected array $_settings = [
         'ext' => '.ts',
         'typescript' => '/usr/local/bin/tsc',
     ];

--- a/src/Filter/TypeScript.php
+++ b/src/Filter/TypeScript.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-
 /**
  * Pre-processing filter that adds support for TypeScript files.
  *
@@ -22,30 +22,30 @@ use MiniAsset\Filter\AssetFilter;
  */
 class TypeScript extends AssetFilter
 {
-
-    protected $_settings = array(
+    protected $_settings = [
         'ext' => '.ts',
         'typescript' => '/usr/local/bin/tsc',
-    );
+    ];
 
     /**
      * Runs `tsc` against files that match the configured extension.
      *
-     * @param  string $filename  Filename being processed.
-     * @param  string $content Content of the file being processed.
+     * @param string $filename  Filename being processed.
+     * @param string $content Content of the file being processed.
      * @return string
      */
-    public function input($filename, $content)
+    public function input(string $filename, string $content): string
     {
         if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
             return $content;
         }
 
         $tmpFile = tempnam(sys_get_temp_dir(), 'TYPESCRIPT');
-        $cmd = $this->_settings['typescript'] . " " . escapeshellarg($filename) . " --out " . $tmpFile;
+        $cmd = $this->_settings['typescript'] . ' ' . escapeshellarg($filename) . ' --out ' . $tmpFile;
         $this->_runCmd($cmd, null);
         $output = file_get_contents($tmpFile);
         unlink($tmpFile);
+
         return $output;
     }
 }

--- a/src/Filter/Uglifyjs.php
+++ b/src/Filter/Uglifyjs.php
@@ -31,7 +31,7 @@ class Uglifyjs extends AssetFilter
      * - `node_path` The path to the node_modules directory where uglify is installed.
      * - `version` Which version of uglify you have installed.
      */
-    protected $_settings = [
+    protected array $_settings = [
         'node' => '/usr/local/bin/node',
         'uglify' => '/usr/local/bin/uglifyjs',
         'node_path' => '/usr/local/lib/node_modules',

--- a/src/Filter/Uglifyjs.php
+++ b/src/Filter/Uglifyjs.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-
 /**
  * Output minifier for uglify-js
  *
@@ -24,7 +24,6 @@ use MiniAsset\Filter\AssetFilter;
  */
 class Uglifyjs extends AssetFilter
 {
-
     /**
      * Settings for Uglify
      *
@@ -32,26 +31,27 @@ class Uglifyjs extends AssetFilter
      * - `node_path` The path to the node_modules directory where uglify is installed.
      * - `version` Which version of uglify you have installed.
      */
-    protected $_settings = array(
+    protected $_settings = [
         'node' => '/usr/local/bin/node',
         'uglify' => '/usr/local/bin/uglifyjs',
         'node_path' => '/usr/local/lib/node_modules',
         'version' => 1,
         'options' => '',
-    );
+    ];
 
     /**
      * Run `uglifyjs` against the output and compress it.
      *
-     * @param  string $target   Name of the file being generated.
-     * @param  string $content The uncompressed contents for $filename.
+     * @param string $target   Name of the file being generated.
+     * @param string $content The uncompressed contents for $filename.
      * @return string Compressed contents.
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         $cmdSep = $this->_settings['version'] <= 1 ? ' - ' : '';
         $cmd = $this->_settings['node'] . ' ' . $this->_settings['uglify'] . $cmdSep . $this->_settings['options'];
-        $env = array('NODE_PATH' => $this->_settings['node_path']);
+        $env = ['NODE_PATH' => $this->_settings['node_path']];
+
         return $this->_runCmd($cmd, $content, $env);
     }
 }

--- a/src/Filter/YuiCss.php
+++ b/src/Filter/YuiCss.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-
 /**
  * A YUI Compressor adapter for compressing CSS.
  * This filter assumes you have Java installed on your system and that its accessible
@@ -22,28 +22,28 @@ use MiniAsset\Filter\AssetFilter;
  */
 class YuiCss extends AssetFilter
 {
-
     /**
      * Settings for YuiCompressor based filters.
      *
      * @var array
      */
-    protected $_settings = array(
-        'path' => 'yuicompressor/yuicompressor.jar'
-    );
+    protected array $_settings = [
+        'path' => 'yuicompressor/yuicompressor.jar',
+    ];
 
     /**
      * Run $input through YuiCompressor
      *
-     * @param  string $target   Filename being generated.
-     * @param  string $content Contents of file
+     * @param string $target   Filename being generated.
+     * @param string $content Contents of file
      * @return string Compressed file
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         $paths = [getcwd(), dirname(dirname(dirname(dirname(__DIR__))))];
         $jar = $this->_findExecutable($paths, $this->_settings['path']);
         $cmd = 'java -jar "' . $jar . '" --type css';
+
         return $this->_runCmd($cmd, $content);
     }
 }

--- a/src/Filter/YuiJs.php
+++ b/src/Filter/YuiJs.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset\Filter;
 
-use MiniAsset\Filter\AssetFilter;
-
 /**
  * A YUI Compressor adapter for compressing Javascript.
  * This filter assumes you have Java installed on your system and that its accessible
@@ -22,28 +22,28 @@ use MiniAsset\Filter\AssetFilter;
  */
 class YuiJs extends AssetFilter
 {
-
     /**
      * Settings for YuiCompressor based filters.
      *
      * @var array
      */
-    protected $_settings = array(
-        'path' => 'yuicompressor/yuicompressor.jar'
-    );
+    protected array $_settings = [
+        'path' => 'yuicompressor/yuicompressor.jar',
+    ];
 
     /**
      * Run $input through YuiCompressor
      *
-     * @param  string $target  Filename being generated.
-     * @param  string $content Contents of file
+     * @param string $target  Filename being generated.
+     * @param string $content Contents of file
      * @return string Compressed file
      */
-    public function output($target, $content)
+    public function output(string $target, string $content): string
     {
         $paths = [getcwd(), dirname(dirname(dirname(dirname(__DIR__))))];
         $jar = $this->_findExecutable($paths, $this->_settings['path']);
         $cmd = 'java -jar "' . $jar . '" --type js';
+
         return $this->_runCmd($cmd, $content);
     }
 }

--- a/src/Middleware/AssetMiddleware.php
+++ b/src/Middleware/AssetMiddleware.php
@@ -19,9 +19,9 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class AssetMiddleware
 {
-    private $config;
-    private $outputDir;
-    private $urlPrefix;
+    private AssetConfig $config;
+    private string $outputDir;
+    private string $urlPrefix;
 
     /**
      * Constructor.
@@ -87,6 +87,11 @@ class AssetMiddleware
         return $response->withHeader('Content-Type', $this->mapType($ext));
     }
 
+    /**
+     * Get the content type for an extension.
+     *
+     * @param $ext string The extension to map to a content type.
+     */
     private function mapType($ext): string
     {
         $types = [

--- a/src/Middleware/AssetMiddleware.php
+++ b/src/Middleware/AssetMiddleware.php
@@ -90,9 +90,10 @@ class AssetMiddleware
     /**
      * Get the content type for an extension.
      *
-     * @param $ext string The extension to map to a content type.
+     * @param string $ext The extension to map to a content type.
+     * @return string
      */
-    private function mapType($ext): string
+    private function mapType(string $ext): string
     {
         $types = [
             'css' => 'application/css',

--- a/src/Output/AssetCacher.php
+++ b/src/Output/AssetCacher.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -14,7 +16,6 @@
 namespace MiniAsset\Output;
 
 use MiniAsset\AssetTarget;
-use MiniAsset\Output\FreshTrait;
 
 /**
  * Writes temporary output files for assets.
@@ -32,14 +33,14 @@ class AssetCacher
      *
      * @var string
      */
-    protected $path;
+    protected string $path;
 
     /**
      * The theme currently being built.
      *
      * @var string
      */
-    protected $theme;
+    protected string $theme;
 
     public function __construct($path, $theme = null)
     {
@@ -50,15 +51,16 @@ class AssetCacher
     /**
      * Get the final build file name for a target.
      *
-     * @param  AssetTarget $target The target to get a name for.
+     * @param \MiniAsset\AssetTarget $target The target to get a name for.
      * @return string
      */
-    public function buildFileName(AssetTarget $target)
+    public function buildFileName(AssetTarget $target): string
     {
         $file = $target->name();
         if ($target->isThemed() && $this->theme) {
             $file = $this->theme . '-' . $file;
         }
+
         return $file;
     }
 
@@ -74,7 +76,7 @@ class AssetCacher
      *
      * @return void
      */
-    public function ensureDir()
+    public function ensureDir(): void
     {
         if (!is_dir($this->path)) {
             mkdir($this->path, 0777);
@@ -84,12 +86,13 @@ class AssetCacher
     /**
      * Get the cached result for a build target.
      *
-     * @param  AssetTarget $target The target to get content for.
+     * @param \MiniAsset\AssetTarget $target The target to get content for.
      * @return string
      */
-    public function read(AssetTarget $target)
+    public function read(AssetTarget $target): string
     {
         $buildName = $this->buildFileName($target);
+
         return file_get_contents($this->path . $buildName);
     }
 
@@ -98,10 +101,10 @@ class AssetCacher
      *
      * Used to locate outputs when determining freshness.
      *
-     * @param  \MiniAsset\AssetTarget $target
+     * @param \MiniAsset\AssetTarget $target
      * @return string The path
      */
-    public function outputDir(AssetTarget $target)
+    public function outputDir(AssetTarget $target): string
     {
         return $this->path;
     }

--- a/src/Output/AssetCacher.php
+++ b/src/Output/AssetCacher.php
@@ -30,19 +30,15 @@ class AssetCacher
 
     /**
      * The output path
-     *
-     * @var string
      */
-    protected string $path;
+    protected ?string $path;
 
     /**
      * The theme currently being built.
-     *
-     * @var string
      */
-    protected string $theme;
+    protected ?string $theme;
 
-    public function __construct($path, $theme = null)
+    public function __construct(string $path, ?string $theme = null)
     {
         $this->path = $path;
         $this->theme = $theme;
@@ -73,8 +69,6 @@ class AssetCacher
 
     /**
      * Create the output directory if it doesn't already exist.
-     *
-     * @return void
      */
     public function ensureDir(): void
     {

--- a/src/Output/AssetWriter.php
+++ b/src/Output/AssetWriter.php
@@ -28,25 +28,23 @@ class AssetWriter
 
     public const BUILD_TIME_FILE = 'mini_asset_build_time';
 
-    protected $timestamp = [];
+    protected array $timestamp = [];
 
-    protected $theme;
+    protected ?string $theme;
 
-    protected $path;
+    protected string $path;
 
     /**
-     * An array of invalidated output files.
-     *
-     * @var array
+     * The most recently invalidated file.
      */
-    protected array $_invalidated = null;
+    protected ?string $_invalidated = null;
 
     /**
      * Constructor.
      *
-     * @param array  $timestamp     The map of extensions and timestamps
+     * @param array $timestamp The map of extensions and timestamps
      * @param string $timestampPath The path to the timestamp file for assets.
-     * @param string $theme         The the theme being assets are being built for.
+     * @param string $theme  The the theme being assets are being built for.
      */
     public function __construct(array $timestamp, string $timestampPath, ?string $theme = null)
     {
@@ -73,7 +71,7 @@ class AssetWriter
      * Writes content into a file
      *
      * @param \MiniAsset\AssetTarget $build   The filename to write.
-     * @param string                 $content The contents to write.
+     * @param string $content The contents to write.
      * @throws \RuntimeException
      * @return bool
      */
@@ -162,9 +160,9 @@ class AssetWriter
      * If timestamps are disabled, false will be returned.
      *
      * @param \MiniAsset\AssetTarget $build The build to get a timestamp for.
-     * @return mixed The last build time, or false.
+     * @return int|false The last build time, or false.
      */
-    public function getTimestamp(AssetTarget $build): mixed
+    public function getTimestamp(AssetTarget $build): int|false
     {
         $ext = $build->ext();
         if (empty($this->timestamp[$ext])) {
@@ -266,10 +264,10 @@ class AssetWriter
      * Modify a file name and append in the timestamp
      *
      * @param string $file The filename.
-     * @param int    $time The timestamp.
+     * @param int|false $time The timestamp.
      * @return string The build filename to cache on disk.
      */
-    protected function _timestampFile(string $file, int $time): string
+    protected function _timestampFile(string $file, int|false $time): string
     {
         if (!$time) {
             return $file;

--- a/src/Output/CachedCompiler.php
+++ b/src/Output/CachedCompiler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -14,9 +16,6 @@
 namespace MiniAsset\Output;
 
 use MiniAsset\AssetTarget;
-use MiniAsset\Output\Compiler;
-use MiniAsset\Output\CompilerInterface;
-use MiniAsset\Output\AssetCacher;
 
 /**
  * An decorator that combines a cacher and a compiler.
@@ -35,11 +34,11 @@ class CachedCompiler implements CompilerInterface
     /**
      * Generate a compiled asset, with all the configured filters applied.
      *
-     * @param  \MiniAsset\AssetTarget $build The target to build
+     * @param \MiniAsset\AssetTarget $build The target to build
      * @return string The processed result of $target and it dependencies.
      * @throws \RuntimeException
      */
-    public function generate(AssetTarget $build)
+    public function generate(AssetTarget $build): string
     {
         if ($this->cacher->isFresh($build)) {
             $contents = $this->cacher->read($build);
@@ -47,6 +46,7 @@ class CachedCompiler implements CompilerInterface
             $contents = $this->compiler->generate($build);
             $this->cacher->write($build, $contents);
         }
+
         return $contents;
     }
 }

--- a/src/Output/CachedCompiler.php
+++ b/src/Output/CachedCompiler.php
@@ -22,8 +22,8 @@ use MiniAsset\AssetTarget;
  */
 class CachedCompiler implements CompilerInterface
 {
-    private $compiler;
-    private $cacher;
+    private Compiler $compiler;
+    private AssetCacher $cacher;
 
     public function __construct(AssetCacher $cacher, Compiler $compiler)
     {

--- a/src/Output/Compiler.php
+++ b/src/Output/Compiler.php
@@ -40,7 +40,7 @@ class Compiler implements CompilerInterface
      * Constructor.
      *
      * @param \MiniAsset\Filter\FilterRegistry $filters The filter registry
-     * @param $debug Whether or not debug mode is enabled.
+     * @param bool $debug Whether or not debug mode is enabled.
      * @return void
      */
     public function __construct(FilterRegistry $filters, bool $debug)

--- a/src/Output/Compiler.php
+++ b/src/Output/Compiler.php
@@ -26,8 +26,6 @@ class Compiler implements CompilerInterface
 {
     /**
      * The filter registry to use.
-     *
-     * @var \MiniAsset\Filter\FilterRegistry
      */
     protected FilterRegistry $filterRegistry;
 
@@ -35,8 +33,6 @@ class Compiler implements CompilerInterface
      * Set to true when in development mode.
      *
      * Enabling this disables output filters.
-     *
-     * @var bool
      */
     protected bool $debug = false;
 
@@ -44,9 +40,10 @@ class Compiler implements CompilerInterface
      * Constructor.
      *
      * @param \MiniAsset\Filter\FilterRegistry $filters The filter registry
+     * @param $debug Whether or not debug mode is enabled.
      * @return void
      */
-    public function __construct(FilterRegistry $filters, $debug)
+    public function __construct(FilterRegistry $filters, bool $debug)
     {
         $this->filterRegistry = $filters;
         $this->debug = $debug;

--- a/src/Output/Compiler.php
+++ b/src/Output/Compiler.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -14,9 +16,7 @@
 namespace MiniAsset\Output;
 
 use MiniAsset\AssetTarget;
-use MiniAsset\Output\CompilerInterface;
 use MiniAsset\Filter\FilterRegistry;
-use RuntimeException;
 
 /**
  * Compiles a set of assets together, and applies filters.
@@ -29,7 +29,7 @@ class Compiler implements CompilerInterface
      *
      * @var \MiniAsset\Filter\FilterRegistry
      */
-    protected $filterRegistry;
+    protected FilterRegistry $filterRegistry;
 
     /**
      * Set to true when in development mode.
@@ -38,12 +38,12 @@ class Compiler implements CompilerInterface
      *
      * @var bool
      */
-    protected $debug = false;
+    protected bool $debug = false;
 
     /**
      * Constructor.
      *
-     * @param  \MiniAsset\Filter\FilterRegistry $filters The filter registry
+     * @param \MiniAsset\Filter\FilterRegistry $filters The filter registry
      * @return void
      */
     public function __construct(FilterRegistry $filters, $debug)
@@ -55,11 +55,11 @@ class Compiler implements CompilerInterface
     /**
      * Generate a compiled asset, with all the configured filters applied.
      *
-     * @param  \MiniAsset\AssetTarget $build The target to build
+     * @param \MiniAsset\AssetTarget $build The target to build
      * @return string The processed result of $target and it dependencies.
      * @throws \RuntimeException
      */
-    public function generate(AssetTarget $build)
+    public function generate(AssetTarget $build): string
     {
         $filters = $this->filterRegistry->collection($build);
         $output = '';
@@ -71,6 +71,7 @@ class Compiler implements CompilerInterface
         if (!$this->debug || php_sapi_name() === 'cli') {
             $output = $filters->output($build->path(), $output);
         }
+
         return trim($output);
     }
 }

--- a/src/Output/CompilerInterface.php
+++ b/src/Output/CompilerInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -20,13 +22,12 @@ use MiniAsset\AssetTarget;
  */
 interface CompilerInterface
 {
-
     /**
      * Generate a compiled asset, with all the configured filters applied.
      *
-     * @param  \MiniAsset\AssetTarget $build The target to build
+     * @param \MiniAsset\AssetTarget $build The target to build
      * @return string The processed result of $target and it dependencies.
      * @throws \RuntimeException
      */
-    public function generate(AssetTarget $build);
+    public function generate(AssetTarget $build): string;
 }

--- a/src/Output/FreshTrait.php
+++ b/src/Output/FreshTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -23,14 +25,14 @@ trait FreshTrait
      *
      * @var int
      */
-    protected $configTime = 0;
+    protected int $configTime = 0;
 
     /**
      * The filter registry to use.
      *
      * @var \MiniAsset\Filter\FilterRegistry
      */
-    protected $filterRegistry;
+    protected FilterRegistry $filterRegistry;
 
     /**
      * Set the modified time of the configuration
@@ -39,11 +41,11 @@ trait FreshTrait
      * This value is used to determine if a build
      * output is still 'fresh'.
      *
-     * @param  int $time The timestamp the configuration files
+     * @param int $time The timestamp the configuration files
      *                   were modified at.
      * @return void
      */
-    public function configTimestamp($time)
+    public function configTimestamp(int $time): void
     {
         $this->configTime = $time;
     }
@@ -51,10 +53,10 @@ trait FreshTrait
     /**
      * Set the filter registry
      *
-     * @param  \MiniAsset\Filter\FilterRegistry $filters The filter set to use.
+     * @param \MiniAsset\Filter\FilterRegistry $filters The filter set to use.
      * @return void
      */
-    public function filterRegistry(FilterRegistry $filters)
+    public function filterRegistry(FilterRegistry $filters): void
     {
         $this->filterRegistry = $filters;
     }
@@ -64,10 +66,10 @@ trait FreshTrait
      * Fresh cached files have timestamps newer than all of the component
      * files.
      *
-     * @param  AssetTarget $target The target file being built.
-     * @return boolean
+     * @param \MiniAsset\AssetTarget $target The target file being built.
+     * @return bool
      */
-    public function isFresh(AssetTarget $target)
+    public function isFresh(AssetTarget $target): bool
     {
         $buildName = $this->buildFileName($target);
         $buildFile = $this->outputDir($target) . DIRECTORY_SEPARATOR . $buildName;
@@ -100,6 +102,7 @@ trait FreshTrait
                 }
             }
         }
+
         return true;
     }
 
@@ -108,8 +111,8 @@ trait FreshTrait
      *
      * Used to locate outputs when determining freshness.
      *
-     * @param  \MiniAsset\AssetTarget $target
+     * @param \MiniAsset\AssetTarget $target
      * @return string The path
      */
-    abstract public function outputDir(AssetTarget $target);
+    abstract public function outputDir(AssetTarget $target): string;
 }

--- a/src/Utility/CssUtils.php
+++ b/src/Utility/CssUtils.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -18,15 +20,15 @@ namespace MiniAsset\Utility;
  */
 class CssUtils
 {
-    const IMPORT_PATTERN = '/^\s*@import\s*(?:(?:([\'"])([^\'"]+)\\1)|(?:url\(([\'"])([^\'"]+)\\3\)))(\s.*)?;/m';
+    public const IMPORT_PATTERN = '/^\s*@import\s*(?:(?:([\'"])([^\'"]+)\\1)|(?:url\(([\'"])([^\'"]+)\\3\)))(\s.*)?;/m';
 
     /**
      * Extract the urls in import directives.
      *
-     * @param  string $css The CSS to parse.
+     * @param string $css The CSS to parse.
      * @return array An array of CSS files that were used in imports.
      */
-    public static function extractImports($css)
+    public static function extractImports(string $css): array
     {
         $imports = [];
         preg_match_all(static::IMPORT_PATTERN, $css, $matches, PREG_SET_ORDER);
@@ -37,6 +39,7 @@ class CssUtils
             $url = empty($match[2]) ? $match[4] : $match[2];
             $imports[] = $url;
         }
+
         return $imports;
     }
 }

--- a/tests/Helpers/MyCallbackProvider.php
+++ b/tests/Helpers/MyCallbackProvider.php
@@ -1,9 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace MiniAsset\Test\Helpers;
 
 class MyCallbackProvider
 {
-
     /**
      * Returns a list of JS files
      *
@@ -13,7 +14,7 @@ class MyCallbackProvider
     {
         return [
             'classes/base_class.js',
-            'classes/nested_class.js'
+            'classes/nested_class.js',
         ];
     }
 }

--- a/tests/TestCase/AssetCollectionTest.php
+++ b/tests/TestCase/AssetCollectionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,10 +15,10 @@
  */
 namespace MiniAsset\Test\TestCase;
 
-use MiniAsset\AssetTarget;
 use MiniAsset\AssetCollection;
-use MiniAsset\Factory;
 use MiniAsset\AssetConfig;
+use MiniAsset\AssetTarget;
+use MiniAsset\Factory;
 use PHPUnit\Framework\TestCase;
 
 class AssetCollectionTest extends TestCase

--- a/tests/TestCase/AssetConfigTest.php
+++ b/tests/TestCase/AssetConfigTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -19,7 +21,6 @@ use RuntimeException;
 
 class AssetConfigTest extends TestCase
 {
-
     /**
      * setup method
      *
@@ -89,37 +90,37 @@ class AssetConfigTest extends TestCase
 
     public function testSettingFilters()
     {
-        $this->config->filters('js', array('Uglifyjs'));
-        $this->assertEquals(array('Uglifyjs'), $this->config->filters('js'));
+        $this->config->filters('js', ['Uglifyjs']);
+        $this->assertEquals(['Uglifyjs'], $this->config->filters('js'));
     }
 
     public function testFiles()
     {
         $result = $this->config->files('libs.js');
-        $expected = array('jquery.js', 'mootools.js', 'class.js');
+        $expected = ['jquery.js', 'mootools.js', 'class.js'];
         $this->assertEquals($expected, $result);
 
         $result = $this->config->files('foo.bar.js');
-        $expected = array('test.js');
+        $expected = ['test.js'];
         $this->assertEquals($expected, $result);
 
-        $this->assertEquals(array(), $this->config->files('nothing here'));
+        $this->assertEquals([], $this->config->files('nothing here'));
     }
 
     public function testPathConstantReplacement()
     {
         $result = $this->config->paths('css');
         $result = str_replace('/', DS, $result);
-        $this->assertEquals(array(WEBROOT . 'css' . DS), $result);
-        $this->assertEquals(array(), $this->config->paths('nothing'));
+        $this->assertEquals([WEBROOT . 'css' . DS], $result);
+        $this->assertEquals([], $this->config->paths('nothing'));
     }
 
     public function testPaths()
     {
-        $this->config->paths('js', null, array('/path/to/files', 'WEBROOT/js'));
+        $this->config->paths('js', null, ['/path/to/files', 'WEBROOT/js']);
         $result = $this->config->paths('js');
         $result = str_replace('/', DS, $result);
-        $expected = array(DS . 'path' . DS . 'to' . DS . 'files', WEBROOT . 'js');
+        $expected = [DS . 'path' . DS . 'to' . DS . 'files', WEBROOT . 'js'];
         $this->assertEquals($expected, $result);
 
         $result = $this->config->paths('js', 'libs.js');
@@ -133,24 +134,24 @@ class AssetConfigTest extends TestCase
         $this->config->addTarget(
             'testing.js',
             [
-            'files' => ['one.js', 'two.js']
+            'files' => ['one.js', 'two.js'],
             ]
         );
-        $this->assertEquals(array('one.js', 'two.js'), $this->config->files('testing.js'));
+        $this->assertEquals(['one.js', 'two.js'], $this->config->files('testing.js'));
     }
 
     public function testAddTargetThemed()
     {
         $this->config->addTarget(
             'testing-two.js',
-            array(
-            'files' => array('one.js', 'two.js'),
-            'filters' => array('uglify'),
-            'theme' => true
-            )
+            [
+            'files' => ['one.js', 'two.js'],
+            'filters' => ['uglify'],
+            'theme' => true,
+            ]
         );
         $this->assertEquals(
-            array('one.js', 'two.js'),
+            ['one.js', 'two.js'],
             $this->config->files('testing-two.js')
         );
         $this->assertTrue($this->config->isThemed('testing-two.js'));
@@ -160,16 +161,16 @@ class AssetConfigTest extends TestCase
     {
         $this->config->addTarget(
             'testing.js',
-            array(
-            'files' => array('one.js', 'two.js'),
-            )
+            [
+            'files' => ['one.js', 'two.js'],
+            ]
         );
         $this->config->addTarget(
             'child.js',
-            array(
-            'files' => array('one.js', 'two.js'),
-            'require' => 'base.js'
-            )
+            [
+            'files' => ['one.js', 'two.js'],
+            'require' => 'base.js',
+            ]
         );
         $this->assertEquals([], $this->config->requires('testing.js'));
         $this->assertEquals(['base.js'], $this->config->requires('child.js'));
@@ -193,47 +194,47 @@ class AssetConfigTest extends TestCase
     public function testFilterConfig()
     {
         $result = $this->config->filterConfig('Uglifyjs');
-        $expected = array('path' => '/path/to/uglify-js');
+        $expected = ['path' => '/path/to/uglify-js'];
         $this->assertEquals($expected, $result);
 
-        $this->config->filterConfig('Sprockets', array('some' => 'value'));
-        $this->assertEquals(array('some' => 'value'), $this->config->filterConfig('Sprockets'));
+        $this->config->filterConfig('Sprockets', ['some' => 'value']);
+        $this->assertEquals(['some' => 'value'], $this->config->filterConfig('Sprockets'));
 
-        $this->assertEquals(array(), $this->config->filterConfig('imaginary'));
+        $this->assertEquals([], $this->config->filterConfig('imaginary'));
     }
 
     public function testFilterConfigPathExpansion()
     {
         $result = $this->config->filterConfig('YuiJs');
-        $expected = array('path' => ROOT . 'to/yuicompressor');
+        $expected = ['path' => ROOT . 'to/yuicompressor'];
         $this->assertEquals($expected, $result);
     }
 
     public function testFilterConfigArray()
     {
-        $this->config->filterConfig('Sprockets', array('some' => 'value'));
+        $this->config->filterConfig('Sprockets', ['some' => 'value']);
 
-        $result = $this->config->filterConfig(array('Uglifyjs', 'Sprockets'));
-        $expected = array(
-            'Sprockets' => array(
-                'some' => 'value'
-            ),
-            'Uglifyjs' => array(
-                'path' => '/path/to/uglify-js'
-            )
-        );
+        $result = $this->config->filterConfig(['Uglifyjs', 'Sprockets']);
+        $expected = [
+            'Sprockets' => [
+                'some' => 'value',
+            ],
+            'Uglifyjs' => [
+                'path' => '/path/to/uglify-js',
+            ],
+        ];
         $this->assertEquals($expected, $result);
     }
 
     public function testTargets()
     {
-        $expected = array(
+        $expected = [
             'libs.js',
             'foo.bar.js',
             'new_file.js',
             'all.css',
-            'pink.css'
-        );
+            'pink.css',
+        ];
         $result = $this->config->targets();
         $this->assertEquals($expected, $result);
     }
@@ -258,7 +259,7 @@ class AssetConfigTest extends TestCase
         try {
             $this->config->set('only.two.allowed', 'smelly');
             $this->assertFalse(true, 'No exception');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertTrue(true, 'Exception was raised.');
         }
     }
@@ -295,10 +296,10 @@ class AssetConfigTest extends TestCase
         $config = AssetConfig::buildFromIniFile($ini);
 
         $result = $config->paths('js');
-        $this->assertEquals(array(WEBROOT . 'js/**'), $result);
+        $this->assertEquals([WEBROOT . 'js/**'], $result);
 
         $result = $config->paths('css');
-        $this->assertEquals(array(WEBROOT . 'css/**'), $result);
+        $this->assertEquals([WEBROOT . 'css/**'], $result);
     }
 
     public function testTheme()

--- a/tests/TestCase/AssetScannerTest.php
+++ b/tests/TestCase/AssetScannerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -18,15 +20,14 @@ use PHPUnit\Framework\TestCase;
 
 class AssetScannerTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
         $this->_testFiles = APP;
-        $paths = array(
+        $paths = [
             $this->_testFiles . 'js' . DS,
-            $this->_testFiles . 'js' . DS . 'classes' . DS
-        );
+            $this->_testFiles . 'js' . DS . 'classes' . DS,
+        ];
         $this->Scanner = new AssetScanner($paths);
     }
 
@@ -41,9 +42,9 @@ class AssetScannerTest extends TestCase
 
     public function testFindOtherExtension()
     {
-        $paths = array(
-            $this->_testFiles . 'css' . DS
-        );
+        $paths = [
+            $this->_testFiles . 'css' . DS,
+        ];
         $scanner = new AssetScanner($paths);
         $result = $scanner->find('other.less');
         $expected = $this->_testFiles . 'css' . DS . 'other.less';
@@ -52,10 +53,10 @@ class AssetScannerTest extends TestCase
 
     public function testNormalizePaths()
     {
-        $paths = array(
+        $paths = [
             $this->_testFiles . 'js',
-            $this->_testFiles . 'js' . DS . 'classes'
-        );
+            $this->_testFiles . 'js' . DS . 'classes',
+        ];
         $scanner = new AssetScanner($paths);
 
         $result = $scanner->find('base_class.js');
@@ -65,17 +66,17 @@ class AssetScannerTest extends TestCase
 
     public function testExpandStarStar()
     {
-        $paths = array(
+        $paths = [
             $this->_testFiles . 'js' . DS . '**',
-        );
+        ];
         $scanner = new AssetScanner($paths);
 
         $result = $scanner->paths();
-        $expected = array(
+        $expected = [
             $this->_testFiles . 'js' . DS,
             $this->_testFiles . 'js' . DS . 'classes' . DS,
-            $this->_testFiles . 'js' . DS . 'secondary' . DS
-        );
+            $this->_testFiles . 'js' . DS . 'secondary' . DS,
+        ];
         $this->assertEquals($expected, $result);
 
         $result = $scanner->find('base_class.js');
@@ -89,10 +90,10 @@ class AssetScannerTest extends TestCase
 
     public function testExpandGlob()
     {
-        $paths = array(
+        $paths = [
             $this->_testFiles . 'js' . DS,
-            $this->_testFiles . 'js' . DS . '*'
-        );
+            $this->_testFiles . 'js' . DS . '*',
+        ];
         $scanner = new AssetScanner($paths);
 
         $result = $scanner->find('base_class.js');

--- a/tests/TestCase/AssetTargetTest.php
+++ b/tests/TestCase/AssetTargetTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)

--- a/tests/TestCase/Cli/BuildTaskTest.php
+++ b/tests/TestCase/Cli/BuildTaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)

--- a/tests/TestCase/Cli/ClearTaskTest.php
+++ b/tests/TestCase/Cli/ClearTaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -107,7 +109,7 @@ class ClearTaskTest extends TestCase
     {
         $files = [
             TMP . 'cache_js/nope.js',
-            TMP . 'cache_js/nope.v12354.js'
+            TMP . 'cache_js/nope.v12354.js',
         ];
         foreach ($files as $file) {
             touch($file);

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,8 +15,6 @@
  */
 namespace MiniAsset;
 
-use MiniAsset\AssetConfig;
-use MiniAsset\Factory;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -187,7 +187,7 @@ class FactoryTest extends TestCase
         $config = AssetConfig::buildFromIniFile(
             $this->integrationFile,
             [
-            'WEBROOT' => TMP
+            'WEBROOT' => TMP,
             ]
         );
         $factory = new Factory($config);
@@ -280,10 +280,10 @@ class FactoryTest extends TestCase
         $expected = [
             'timestamp' => [
                 'js' => true,
-                'css' => false
+                'css' => false,
             ],
             'path' => TMP,
-            'theme' => 'Red'
+            'theme' => 'Red',
         ];
         $this->assertEquals($expected, $writer->config());
     }
@@ -297,7 +297,7 @@ class FactoryTest extends TestCase
         $expected = [
             'timestamp' => [
                 'js' => true,
-                'css' => false
+                'css' => false,
             ],
             'path' => WEBROOT . 'timestamp' . DIRECTORY_SEPARATOR,
             'theme' => '',

--- a/tests/TestCase/File/GlobTest.php
+++ b/tests/TestCase/File/GlobTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)

--- a/tests/TestCase/File/LocalTest.php
+++ b/tests/TestCase/File/LocalTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)

--- a/tests/TestCase/File/RemoteTest.php
+++ b/tests/TestCase/File/RemoteTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)

--- a/tests/TestCase/File/TargetTest.php
+++ b/tests/TestCase/File/TargetTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -26,7 +28,7 @@ class TargetTest extends TestCase
         $this->compiler = $this->getMockBuilder('MiniAsset\Output\CompilerInterface')->getMock();
 
         $files = [
-            new Local(APP . 'js/classes/base_class_two.js')
+            new Local(APP . 'js/classes/base_class_two.js'),
         ];
         $this->asset = new AssetTarget(TMP . 'all.css', $files);
         $this->target = new Target($this->asset, $this->compiler);

--- a/tests/TestCase/Filter/ClosureJsTest.php
+++ b/tests/TestCase/Filter/ClosureJsTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,12 +15,10 @@
  */
 namespace MiniAsset\Test\TestCase\Filter;
 
-use MiniAsset\Filter\ClosureJs;
 use PHPUnit\Framework\TestCase;
 
 class ClosureJsTest extends TestCase
 {
-
     public function testCommand()
     {
         $filter = $this->getMockBuilder('MiniAsset\Filter\ClosureJs')
@@ -33,7 +33,6 @@ class ClosureJsTest extends TestCase
             ->with($this->matchesRegularExpression('/java -jar "closure\/compiler\.jar" --js=(.*)\/CLOSURE(.*) --warning_level="QUIET"/'));
         $filter->output('file.js', 'var a = 1;');
 
-
         $filter = $this->getMockBuilder('MiniAsset\Filter\ClosureJs')
             ->onlyMethods(['_findExecutable', '_runCmd'])
             ->getMock();
@@ -43,7 +42,7 @@ class ClosureJsTest extends TestCase
         $filter->expects($this->once())
             ->method('_runCmd')
             ->with($this->matchesRegularExpression('/java -jar "closure\/compiler\.jar" --js=(.*)\/CLOSURE(.*) --warning_level="QUIET" --language_in="ECMASCRIPT5"/'));
-        $filter->settings(array('language_in' => 'ECMASCRIPT5'));
+        $filter->settings(['language_in' => 'ECMASCRIPT5']);
         $filter->output('file.js', 'var a = 1;');
     }
 }

--- a/tests/TestCase/Filter/FilterRegistryTest.php
+++ b/tests/TestCase/Filter/FilterRegistryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -26,7 +28,7 @@ class FilterRegistryTest extends TestCase
         parent::setUp();
         $this->filters = [
             'noop' => new AssetFilter(),
-            'simple' => new AssetFilter()
+            'simple' => new AssetFilter(),
         ];
         $this->registry = new FilterRegistry($this->filters);
     }

--- a/tests/TestCase/Filter/HoganTest.php
+++ b/tests/TestCase/Filter/HoganTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -18,18 +20,17 @@ use PHPUnit\Framework\TestCase;
 
 class HoganTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
         $this->_path = APP . '/hogan/';
 
         $this->filter = new Hogan();
-        $settings = array(
+        $settings = [
             'node' => trim(`which node`),
             'node_path' => getenv('NODE_PATH'),
             'paths' => [],
-        );
+        ];
         $this->filter->settings($settings);
 
         $hasHogan = `which hulk`;

--- a/tests/TestCase/Filter/ImportInlineTest.php
+++ b/tests/TestCase/Filter/ImportInlineTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -18,16 +20,15 @@ use PHPUnit\Framework\TestCase;
 
 class ImportInlineTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
         $this->filter = new ImportInline();
-        $settings = array(
-            'paths' => array(
-                APP . 'css/'
-            ),
-        );
+        $settings = [
+            'paths' => [
+                APP . 'css/',
+            ],
+        ];
         $this->filter->settings($settings);
     }
 

--- a/tests/TestCase/Filter/LessCssTest.php
+++ b/tests/TestCase/Filter/LessCssTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -20,7 +22,6 @@ use PHPUnit\Framework\TestCase;
 
 class LessCssTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -28,7 +29,7 @@ class LessCssTest extends TestCase
         $this->filter = new LessCss();
         $this->filter->settings(
             [
-            'paths' => [$this->_cssDir]
+            'paths' => [$this->_cssDir],
             ]
         );
     }
@@ -36,7 +37,7 @@ class LessCssTest extends TestCase
     public function testGetDependencies()
     {
         $files = [
-            new Local($this->_cssDir . 'other.less')
+            new Local($this->_cssDir . 'other.less'),
         ];
         $target = new AssetTarget('test.css', $files);
         $result = $this->filter->getDependencies($target);

--- a/tests/TestCase/Filter/PipeInputFilterTest.php
+++ b/tests/TestCase/Filter/PipeInputFilterTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -20,7 +22,6 @@ use PHPUnit\Framework\TestCase;
 
 class PipeInputFilterTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -34,7 +35,7 @@ class PipeInputFilterTest extends TestCase
 
     public function testParsing()
     {
-        $this->filter->settings(array('command' => '/bin/cat'));
+        $this->filter->settings(['command' => '/bin/cat']);
 
         $content = file_get_contents($this->_cssDir . 'test.scss');
         $result = $this->filter->input($this->_cssDir . 'test.scss', $content);
@@ -44,13 +45,13 @@ class PipeInputFilterTest extends TestCase
 
     public function testGetDependenciesFalse()
     {
-        $this->filter->settings(array(
+        $this->filter->settings([
             'dependencies' => false,
             'optional_dependency_prefix' => false,
-        ));
+        ]);
 
         $files = [
-            new Local($this->_cssDir . 'test.scss')
+            new Local($this->_cssDir . 'test.scss'),
         ];
         $target = new AssetTarget('test.css', $files);
         $result = $this->filter->getDependencies($target);
@@ -60,13 +61,13 @@ class PipeInputFilterTest extends TestCase
 
     public function testGetDependenciesTrue()
     {
-        $this->filter->settings(array(
+        $this->filter->settings([
             'dependencies' => true,
             'optional_dependency_prefix' => '_',
-        ));
+        ]);
 
         $files = [
-            new Local($this->_cssDir . 'test.scss')
+            new Local($this->_cssDir . 'test.scss'),
         ];
         $target = new AssetTarget('test.css', $files);
         $result = $this->filter->getDependencies($target);
@@ -79,13 +80,13 @@ class PipeInputFilterTest extends TestCase
 
     public function testGetDependenciesMissingDependency()
     {
-        $this->filter->settings(array(
+        $this->filter->settings([
             'dependencies' => true,
             'optional_dependency_prefix' => '_',
-        ));
+        ]);
 
         $files = [
-            new Local($this->_cssDir . 'broken.scss')
+            new Local($this->_cssDir . 'broken.scss'),
         ];
         $target = new AssetTarget('test.css', $files);
         $result = $this->filter->getDependencies($target);

--- a/tests/TestCase/Filter/PipeOutputFilterTest.php
+++ b/tests/TestCase/Filter/PipeOutputFilterTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -18,7 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 class PipeOutputFilterTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/TestCase/Filter/ScssFilterTest.php
+++ b/tests/TestCase/Filter/ScssFilterTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -20,14 +22,13 @@ use PHPUnit\Framework\TestCase;
 
 class ScssFilterTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
         $this->_cssDir = APP . 'css' . DS;
         $this->filter = new ScssFilter();
         $this->filter->settings([
-            'paths' => [$this->_cssDir]
+            'paths' => [$this->_cssDir],
         ]);
     }
 
@@ -37,7 +38,7 @@ class ScssFilterTest extends TestCase
         if (!$hasSass) {
             $this->markTestSkipped('Requries ruby and sass to be installed.');
         }
-        $this->filter->settings(array('sass' => trim($hasSass)));
+        $this->filter->settings(['sass' => trim($hasSass)]);
 
         $content = file_get_contents($this->_cssDir . 'test.scss');
         $result = $this->filter->input($this->_cssDir . 'test.scss', $content);
@@ -48,7 +49,7 @@ class ScssFilterTest extends TestCase
     public function testGetDependencies()
     {
         $files = [
-            new Local($this->_cssDir . 'test.scss')
+            new Local($this->_cssDir . 'test.scss'),
         ];
         $target = new AssetTarget('test.css', $files);
         $result = $this->filter->getDependencies($target);
@@ -62,7 +63,7 @@ class ScssFilterTest extends TestCase
     public function testGetDependenciesMissingDependency()
     {
         $files = [
-            new Local($this->_cssDir . 'broken.scss')
+            new Local($this->_cssDir . 'broken.scss'),
         ];
         $target = new AssetTarget('test.css', $files);
         $result = $this->filter->getDependencies($target);
@@ -78,7 +79,7 @@ class ScssFilterTest extends TestCase
             'imports' => [$this->_cssDir . DIRECTORY_SEPARATOR . 'reset'],
         ]);
         $files = [
-            new Local($this->_cssDir . 'test_imports.scss')
+            new Local($this->_cssDir . 'test_imports.scss'),
         ];
         $target = new AssetTarget('test.css', $files);
         $result = $this->filter->getDependencies($target);

--- a/tests/TestCase/Filter/SimpleCssMinTest.php
+++ b/tests/TestCase/Filter/SimpleCssMinTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -18,7 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 class SimpleCssMinTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/TestCase/Filter/SprocketsTest.php
+++ b/tests/TestCase/Filter/SprocketsTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -20,7 +22,6 @@ use PHPUnit\Framework\TestCase;
 
 class SprocketsTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -28,12 +29,12 @@ class SprocketsTest extends TestCase
         $this->_jsDir = $this->_testFiles . 'js' . DS;
 
         $this->filter = new Sprockets();
-        $settings = array(
-            'paths' => array(
+        $settings = [
+            'paths' => [
                 $this->_jsDir,
                 $this->_jsDir . 'classes' . DS,
-            )
-        );
+            ],
+        ];
         $this->filter->settings($settings);
     }
 
@@ -146,7 +147,7 @@ TEXT;
     public function testGetDependenciesRecursive()
     {
         $files = [
-            new Local($this->_jsDir . 'classes/nested_class.js')
+            new Local($this->_jsDir . 'classes/nested_class.js'),
         ];
         $target = new AssetTarget('test.js', $files);
         $result = $this->filter->getDependencies($target);
@@ -163,7 +164,7 @@ TEXT;
     public function testGetDependenciesMultiple()
     {
         $files = [
-            new Local($this->_jsDir . 'classes/slideshow.js')
+            new Local($this->_jsDir . 'classes/slideshow.js'),
         ];
         $target = new AssetTarget('test.js', $files);
         $result = $this->filter->getDependencies($target);

--- a/tests/TestCase/Filter/TimestampImageTest.php
+++ b/tests/TestCase/Filter/TimestampImageTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -18,7 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 class TimestampImageTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/TestCase/Middleware/AssetMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AssetMiddlewareTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,11 +15,11 @@
  */
 namespace MiniAsset\Test\TestCase;
 
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequestFactory;
 use MiniAsset\AssetConfig;
 use MiniAsset\Middleware\AssetMiddleware;
 use PHPUnit\Framework\TestCase;
-use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\Diactoros\Response;
 
 class AssetMiddlewareTest extends TestCase
 {
@@ -37,7 +39,7 @@ class AssetMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals(
             [
-            'REQUEST_URI' => '/wrong/assets/path'
+            'REQUEST_URI' => '/wrong/assets/path',
             ]
         );
         $response = new Response();
@@ -52,7 +54,7 @@ class AssetMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals(
             [
-            'REQUEST_URI' => '/assets/nope.js'
+            'REQUEST_URI' => '/assets/nope.js',
             ]
         );
         $response = new Response();
@@ -69,13 +71,13 @@ class AssetMiddlewareTest extends TestCase
         $this->config->addTarget(
             'invalid.css',
             [
-            'files' => [APP . 'invalid.css']
+            'files' => [APP . 'invalid.css'],
             ]
         );
 
         $request = ServerRequestFactory::fromGlobals(
             [
-            'REQUEST_URI' => '/assets/invalid.css'
+            'REQUEST_URI' => '/assets/invalid.css',
             ]
         );
         $response = new Response();
@@ -93,7 +95,7 @@ class AssetMiddlewareTest extends TestCase
         file_put_contents(sys_get_temp_dir() . '/all.css', 'cached data');
         $request = ServerRequestFactory::fromGlobals(
             [
-            'REQUEST_URI' => '/assets/all.css'
+            'REQUEST_URI' => '/assets/all.css',
             ]
         );
         $response = new Response();
@@ -113,7 +115,7 @@ class AssetMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals(
             [
-            'REQUEST_URI' => '/assets/all.css'
+            'REQUEST_URI' => '/assets/all.css',
             ]
         );
         $response = new Response();
@@ -145,7 +147,7 @@ class AssetMiddlewareTest extends TestCase
     {
         $request = ServerRequestFactory::fromGlobals(
             [
-            'REQUEST_URI' => $uri
+            'REQUEST_URI' => $uri,
             ]
         );
 

--- a/tests/TestCase/Output/AssetCacherTest.php
+++ b/tests/TestCase/Output/AssetCacherTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,15 +15,14 @@
  */
 namespace MiniAsset\Test\TestCase\Output;
 
-use MiniAsset\Output\AssetCacher;
 use MiniAsset\AssetTarget;
 use MiniAsset\File\Local;
 use MiniAsset\Filter\FilterRegistry;
+use MiniAsset\Output\AssetCacher;
 use PHPUnit\Framework\TestCase;
 
 class AssetCacherTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/TestCase/Output/AssetCacherTest.php
+++ b/tests/TestCase/Output/AssetCacherTest.php
@@ -40,7 +40,7 @@ class AssetCacherTest extends TestCase
         $filter = $this->getMockBuilder('MiniAsset\Filter\FilterInterface')->getMock();
         $filter->method('getDependencies')
             ->will($this->returnValue([]));
-        $registry = new FilterRegistry([$filter]);
+        $registry = new FilterRegistry(['mock' => $filter]);
 
         $this->cacher = new AssetCacher(TMP);
         $this->cacher->filterRegistry($registry);

--- a/tests/TestCase/Output/AssetWriterTest.php
+++ b/tests/TestCase/Output/AssetWriterTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -13,10 +15,10 @@
  */
 namespace MiniAsset\Test\TestCase\Output;
 
-use MiniAsset\Output\AssetWriter;
 use MiniAsset\AssetTarget;
 use MiniAsset\File\Local;
 use MiniAsset\Filter\FilterRegistry;
+use MiniAsset\Output\AssetWriter;
 use PHPUnit\Framework\TestCase;
 
 class AssetWriterTest extends TestCase

--- a/tests/TestCase/Output/AssetWriterTest.php
+++ b/tests/TestCase/Output/AssetWriterTest.php
@@ -35,7 +35,7 @@ class AssetWriterTest extends TestCase
         $filter = $this->getMockBuilder('MiniAsset\Filter\FilterInterface')->getMock();
         $filter->method('getDependencies')
             ->will($this->returnValue([]));
-        $registry = new FilterRegistry([$filter]);
+        $registry = new FilterRegistry(['mock' => $filter]);
 
         $this->target = new AssetTarget(TMP . 'test.js', $this->files, [], [], true);
         $this->writer = new AssetWriter(['js' => false, 'css' => false], TMP);

--- a/tests/TestCase/Output/CachedCompilerTest.php
+++ b/tests/TestCase/Output/CachedCompilerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -21,7 +23,6 @@ use PHPUnit\Framework\TestCase;
 
 class CachedCompilerTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -35,18 +36,18 @@ class CachedCompilerTest extends TestCase
         $this->config->paths(
             'js',
             null,
-            array(
+            [
             $this->_testFiles . 'js' . DS,
             $this->_testFiles . 'js' . DS . '*',
-            )
+            ]
         );
         $this->config->paths(
             'css',
             null,
-            array(
+            [
             $this->_testFiles . 'css' . DS,
             $this->_testFiles . 'css' . DS . '*',
-            )
+            ]
         );
 
         if (file_exists(TMP . '/all.css')) {
@@ -57,6 +58,7 @@ class CachedCompilerTest extends TestCase
     protected function instance()
     {
         $factory = new Factory($this->config);
+
         return $factory->cachedCompiler(TMP);
     }
 
@@ -66,6 +68,7 @@ class CachedCompilerTest extends TestCase
             new Local(APP . 'css/other.less'),
             new Local(APP . 'css/nav.css'),
         ];
+
         return new AssetTarget(TMP . 'all.css', $files);
     }
 

--- a/tests/TestCase/Output/CompilerTest.php
+++ b/tests/TestCase/Output/CompilerTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -21,7 +23,6 @@ use PHPUnit\Framework\TestCase;
 
 class CompilerTest extends TestCase
 {
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -35,24 +36,25 @@ class CompilerTest extends TestCase
         $this->config->paths(
             'js',
             null,
-            array(
+            [
             $this->_testFiles . 'js' . DS,
             $this->_testFiles . 'js' . DS . '*',
-            )
+            ]
         );
         $this->config->paths(
             'css',
             null,
-            array(
+            [
             $this->_testFiles . 'css' . DS,
             $this->_testFiles . 'css' . DS . '*',
-            )
+            ]
         );
     }
 
     protected function instance()
     {
         $factory = new Factory($this->config);
+
         return $factory->compiler();
     }
 

--- a/tests/TestCase/Utility/CssUtilsTest.php
+++ b/tests/TestCase/Utility/CssUtilsTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * MiniAsset
  * Copyright (c) Mark Story (http://mark-story.com)
@@ -37,7 +39,7 @@ CSS;
             'second.css',
             'third.css',
             '../../relative-path.css',
-            'http://example.com/dir/absolute-path.css'
+            'http://example.com/dir/absolute-path.css',
         ];
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
For the 2.x branch of mini-asset, I would like to narrow the requirements to php 8.1 as this library can benefit from the type system improvements and reduced documentation boilerplate. It also helps to unblock a more completely typed AssetCompress package for CakePHP 5.x