### PR TITLE
Allow multiple extensions for ScssFilter

### DIFF
--- a/src/Filter/ScssFilter.php
+++ b/src/Filter/ScssFilter.php
@@ -30,7 +30,7 @@ class ScssFilter extends AssetFilter
     }
 
     protected $_settings = array(
-        'ext' => '.scss',
+        'ext' => ['.scss', '.sass'],
         'sass' => '/usr/bin/sass',
         'path' => '/usr/bin',
         'imports' => [],
@@ -57,9 +57,17 @@ class ScssFilter extends AssetFilter
      */
     public function input($filename, $content)
     {
-        if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
+        $ext = '.' . pathinfo($filename, PATHINFO_EXTENSION);
+
+        $acceptedExt = $this->_settings['ext'];
+        if (is_string($acceptedExt)) {
+            $acceptedExt = [$acceptedExt];
+        }
+
+        if (!in_array($ext, $acceptedExt)) {
             return $content;
         }
+
         $filename = preg_replace('/ /', '\\ ', $filename);
         $cmd = $this->_settings['sass'];
         foreach ($this->_settings['imports'] as $path) {


### PR DESCRIPTION
I have a mix of sass and scss files which I want to process with ScssFilter but it only allows one extension.

I've added the option to use `ext` as an array of extensions. I had to modify CssDependencyTrait so that it accepts an array and looks for dependencies with multiple extensions. It works for me but I'm not sure it won't break anything else.