### PR TITLE
Update composer.json to reflect supported version of scssphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "natxet/CssMin": "For using the CssMin filter.",
     "tchwork/jsqueeze": "For using the JSqueeze filter.",
     "tedivm/jshrink": "For using the JShrink filter.",
-    "scssphp/scssphp": "For using the ScssPHP filter.",
+    "scssphp/scssphp:1.x": "For using the ScssPHP filter.",
     "oyejorge/less.php": "For using the LessDotPHP filter, see https://github.com/oyejorge/less.php",
     "zendframework/diactoros": "The middleware layer relies on zendframework/diactoros."
   },


### PR DESCRIPTION
The ScssPHP filter does not work with the latest version of scssphp/scssphp, so until that is changed I suggest this small edit to save users some time.